### PR TITLE
refactor(crypto): remove deprecated methods and harden crypto module

### DIFF
--- a/crypto/src/main/java/org/tron/common/crypto/ECKey.java
+++ b/crypto/src/main/java/org/tron/common/crypto/ECKey.java
@@ -246,30 +246,6 @@ public class ECKey implements Serializable, SignInterface {
   }
 
   /**
-   * Utility for compressing an elliptic curve point. Returns the same point if it's already
-   * compressed. See the ECKey class docs for a discussion of point compression.
-   *
-   * @param uncompressed -
-   * @return -
-   * @deprecated per-point compression property will be removed in Bouncy Castle
-   */
-  public static ECPoint compressPoint(ECPoint uncompressed) {
-    return CURVE.getCurve().decodePoint(uncompressed.getEncoded(true));
-  }
-
-  /**
-   * Utility for decompressing an elliptic curve point. Returns the same point if it's already
-   * compressed. See the ECKey class docs for a discussion of point compression.
-   *
-   * @param compressed -
-   * @return -
-   * @deprecated per-point compression property will be removed in Bouncy Castle
-   */
-  public static ECPoint decompressPoint(ECPoint compressed) {
-    return CURVE.getCurve().decodePoint(compressed.getEncoded(false));
-  }
-
-  /**
    * Creates an ECKey given the private key only.
    *
    * @param privKey -

--- a/crypto/src/main/java/org/tron/common/crypto/SignUtils.java
+++ b/crypto/src/main/java/org/tron/common/crypto/SignUtils.java
@@ -48,7 +48,17 @@ public class SignUtils {
       byte[] messageHash, SignatureInterface signatureInterface, boolean isECKeyCryptoEngine)
       throws SignatureException {
     if (isECKeyCryptoEngine) {
+      if (!(signatureInterface instanceof ECDSASignature)) {
+        throw new IllegalArgumentException(
+            "Expected ECDSASignature for ECKey engine, got: "
+                + signatureInterface.getClass().getName());
+      }
       return ECKey.signatureToAddress(messageHash, (ECDSASignature) signatureInterface);
+    }
+    if (!(signatureInterface instanceof SM2Signature)) {
+      throw new IllegalArgumentException(
+          "Expected SM2Signature for SM2 engine, got: "
+              + signatureInterface.getClass().getName());
     }
     return SM2.signatureToAddress(messageHash, (SM2Signature) signatureInterface);
   }

--- a/crypto/src/main/java/org/tron/common/crypto/SignUtils.java
+++ b/crypto/src/main/java/org/tron/common/crypto/SignUtils.java
@@ -51,14 +51,16 @@ public class SignUtils {
       if (!(signatureInterface instanceof ECDSASignature)) {
         throw new IllegalArgumentException(
             "Expected ECDSASignature for ECKey engine, got: "
-                + signatureInterface.getClass().getName());
+                + (signatureInterface == null ? "null"
+                    : signatureInterface.getClass().getName()));
       }
       return ECKey.signatureToAddress(messageHash, (ECDSASignature) signatureInterface);
     }
     if (!(signatureInterface instanceof SM2Signature)) {
       throw new IllegalArgumentException(
           "Expected SM2Signature for SM2 engine, got: "
-              + signatureInterface.getClass().getName());
+              + (signatureInterface == null ? "null"
+                  : signatureInterface.getClass().getName()));
     }
     return SM2.signatureToAddress(messageHash, (SM2Signature) signatureInterface);
   }

--- a/crypto/src/main/java/org/tron/common/crypto/sm2/SM2.java
+++ b/crypto/src/main/java/org/tron/common/crypto/sm2/SM2.java
@@ -50,17 +50,17 @@ import org.tron.common.utils.ByteUtil;
 @Slf4j(topic = "crypto")
 public class SM2 implements Serializable, SignInterface {
 
-  private static BigInteger SM2_N = new BigInteger(
+  private static final BigInteger SM2_N = new BigInteger(
       "FFFFFFFEFFFFFFFFFFFFFFFFFFFFFFFF7203DF6B21C6052B53BBF40939D54123", 16);
-  private static BigInteger SM2_P = new BigInteger(
+  private static final BigInteger SM2_P = new BigInteger(
       "FFFFFFFEFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF00000000FFFFFFFFFFFFFFFF", 16);
-  private static BigInteger SM2_A = new BigInteger(
+  private static final BigInteger SM2_A = new BigInteger(
       "FFFFFFFEFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF00000000FFFFFFFFFFFFFFFC", 16);
-  private static BigInteger SM2_B = new BigInteger(
+  private static final BigInteger SM2_B = new BigInteger(
       "28E9FA9E9D9F5E344D5A9E4BCF6509A7F39789F515AB8F92DDBCBD414D940E93", 16);
-  private static BigInteger SM2_GX = new BigInteger(
+  private static final BigInteger SM2_GX = new BigInteger(
       "32C4AE2C1F1981195F9904466A39C9948FE30BBFF2660BE1715A4589334C74C7", 16);
-  private static BigInteger SM2_GY = new BigInteger(
+  private static final BigInteger SM2_GY = new BigInteger(
       "BC3736A2F4F6779C59BDCEE36B692153D0A9877CC62A474002DF32E52139F0A0", 16);
 
   private static ECDomainParameters ecc_param;
@@ -206,30 +206,6 @@ public class SM2 implements Serializable, SignInterface {
     return ecc_param.getCurve().createPoint(xCoord, yCoord);
   }
 
-
-  /**
-   * Utility for compressing an elliptic curve point. Returns the same point if it's already
-   * compressed. See the ECKey class docs for a discussion of point compression.
-   *
-   * @param uncompressed -
-   * @return -
-   * @deprecated per-point compression property will be removed in Bouncy Castle
-   */
-  public static ECPoint compressPoint(ECPoint uncompressed) {
-    return ecc_param.getCurve().decodePoint(uncompressed.getEncoded(true));
-  }
-
-  /**
-   * Utility for decompressing an elliptic curve point. Returns the same point if it's already
-   * compressed. See the ECKey class docs for a discussion of point compression.
-   *
-   * @param compressed -
-   * @return -
-   * @deprecated per-point compression property will be removed in Bouncy Castle
-   */
-  public static ECPoint decompressPoint(ECPoint compressed) {
-    return ecc_param.getCurve().decodePoint(compressed.getEncoded(false));
-  }
 
   /**
    * Creates an SM2 given the private key only.


### PR DESCRIPTION
## Summary

- Remove `compressPoint`/`decompressPoint` from both `ECKey` and `SM2`
  (all 4 were `@deprecated`, zero callers confirmed by grep)
- Add `private static final` to SM2 curve domain parameters
  (`SM2_N`, `SM2_P`, `SM2_A`, `SM2_B`, `SM2_GX`, `SM2_GY`)
- Add `instanceof` type guards in `SignUtils.signatureToAddress`
  to replace silent `ClassCastException` with descriptive
  `IllegalArgumentException` on engine/signature-type mismatch

## Compatibility

Removing `compressPoint`/`decompressPoint` is a binary-incompatible
change. External code calling these methods via direct reference will
encounter `NoSuchMethodError` at runtime after upgrading. Migration:
use `ECPoint.getEncoded(boolean)` directly.

## Test plan

- [x] `./gradlew :framework:test --tests "org.tron.common.crypto.*"` — all pass
- [x] `./gradlew :framework:test --tests "org.tron.core.net.messagehandler.PbftMsgHandlerTest"` — pass
- [x] `./gradlew :framework:test --tests "org.tron.core.pbft.PbftApiTest"` — pass
- [x] `./gradlew :chainbase:test` — all pass

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes deprecated point-compression helpers and hardens signature-type checks to prevent silent casting errors. Also makes SM2 curve constants immutable and makes `SignUtils.signatureToAddress` error messages null-safe.

- **Refactors**
  - Removed `compressPoint`/`decompressPoint` from `ECKey` and `SM2` (no callers).
  - Added `instanceof` checks and null-safe errors in `SignUtils.signatureToAddress`; throw `IllegalArgumentException` on engine/signature mismatch.
  - Marked SM2 domain parameters (`SM2_N`, `SM2_P`, `SM2_A`, `SM2_B`, `SM2_GX`, `SM2_GY`) as `private static final`.

- **Migration**
  - Removal is binary-incompatible; direct callers will hit `NoSuchMethodError`.
  - Use `ECPoint.getEncoded(boolean)` for point compression/decompression.

<sup>Written for commit e8cd1040d85cab4463ca9ee5f9dc5f0fc89c82b8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Removed public point compression/decompression utility methods from cryptographic APIs.
  * Added runtime signature-type validation to fail fast on mismatched signature implementations.
  * Made cryptographic domain constants immutable to improve stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->