### PR TITLE
fix(crypto): harden shielded transaction safety and input validation

### DIFF
--- a/actuator/src/main/java/org/tron/core/vm/PrecompiledContracts.java
+++ b/actuator/src/main/java/org/tron/core/vm/PrecompiledContracts.java
@@ -1148,8 +1148,8 @@ public class PrecompiledContracts {
               new LibrustzcashParam.MerkleHashParams(
                   i, UNCOMMITTED[i], UNCOMMITTED[i], UNCOMMITTED[i + 1]));
         }
-      } catch (Throwable any) {
-        logger.info("Initialize UNCOMMITTED array failed:{}", any.getMessage());
+      } catch (ZksnarkException e) {
+        throw new RuntimeException("Failed to initialize UNCOMMITTED array", e);
       }
     }
 
@@ -1258,7 +1258,7 @@ public class PrecompiledContracts {
       if (success) {
         return Pair.of(true, merge(DataWord.ONE().getData(), result));
       } else {
-        return Pair.of(true, DataWord.ZERO().getData());
+        return Pair.of(false, EMPTY_BYTE_ARRAY);
       }
     }
   }
@@ -1282,6 +1282,10 @@ public class PrecompiledContracts {
       }
       boolean result;
       long ctx = JLibrustzcash.librustzcashSaplingVerificationCtxInit();
+      if (ctx == 0) {
+        logger.info("VerifyMintProof: failed to init verification context");
+        return Pair.of(false, EMPTY_BYTE_ARRAY);
+      }
       try {
         byte[] cm = new byte[32];
         byte[] cv = new byte[32];
@@ -1328,7 +1332,7 @@ public class PrecompiledContracts {
       } finally {
         JLibrustzcash.librustzcashSaplingVerificationCtxFree(ctx);
       }
-      return Pair.of(true, DataWord.ZERO().getData());
+      return Pair.of(false, EMPTY_BYTE_ARRAY);
     }
   }
 
@@ -1477,6 +1481,10 @@ public class PrecompiledContracts {
 
         boolean withNoTimeout = countDownLatch.await(getCPUTimeLeftInNanoSecond(),
             TimeUnit.NANOSECONDS);
+        if (!withNoTimeout) {
+          futures.forEach(f -> f.cancel(true));
+          return Pair.of(true, DataWord.ZERO().getData());
+        }
         boolean checkResult = true;
         for (Future<Boolean> future : futures) {
           boolean eachTaskResult = future.get();
@@ -1497,7 +1505,7 @@ public class PrecompiledContracts {
         }
         logger.info("VerifyTransferProof exception: " + errorMsg);
       }
-      return Pair.of(true, DataWord.ZERO().getData());
+      return Pair.of(false, EMPTY_BYTE_ARRAY);
     }
 
     private static class SaplingCheckSpendTask implements Callable<Boolean> {
@@ -1527,17 +1535,13 @@ public class PrecompiledContracts {
 
       @Override
       public Boolean call() throws ZksnarkException {
-        boolean result;
         try {
-          result = JLibrustzcash.librustzcashSaplingCheckSpendNew(
+          return JLibrustzcash.librustzcashSaplingCheckSpendNew(
               new LibrustzcashParam.CheckSpendNewParams(this.cv, this.anchor, this.nullifier,
                   this.rk, this.zkproof, this.spendAuthSig, this.signHash));
-        } catch (ZksnarkException e) {
-          throw e;
         } finally {
           countDownLatch.countDown();
         }
-        return result;
       }
     }
 
@@ -1561,17 +1565,13 @@ public class PrecompiledContracts {
 
       @Override
       public Boolean call() throws ZksnarkException {
-        boolean result;
         try {
-          result = JLibrustzcash.librustzcashSaplingCheckOutputNew(
+          return JLibrustzcash.librustzcashSaplingCheckOutputNew(
               new LibrustzcashParam.CheckOutputNewParams(this.cv, this.cm,
                   this.ephemeralKey, this.zkproof));
-        } catch (ZksnarkException e) {
-          throw e;
         } finally {
           countDownLatch.countDown();
         }
-        return result;
       }
     }
 
@@ -1602,18 +1602,14 @@ public class PrecompiledContracts {
 
       @Override
       public Boolean call() throws ZksnarkException {
-        boolean result;
         try {
-          result = JLibrustzcash.librustzcashSaplingFinalCheckNew(
+          return JLibrustzcash.librustzcashSaplingFinalCheckNew(
               new LibrustzcashParam.FinalCheckNewParams(this.valueBalance, this.bindingSig,
                   this.signHash, this.spendCvs, this.spendCvLen,
                   this.receiveCvs, this.receiveCvLen));
-        } catch (ZksnarkException e) {
-          throw e;
         } finally {
           countDownLatch.countDown();
         }
-        return result;
       }
     }
   }
@@ -1637,6 +1633,10 @@ public class PrecompiledContracts {
       }
       boolean result;
       long ctx = JLibrustzcash.librustzcashSaplingVerificationCtxInit();
+      if (ctx == 0) {
+        logger.info("VerifyBurnProof: failed to init verification context");
+        return Pair.of(false, EMPTY_BYTE_ARRAY);
+      }
       try {
         byte[] nullifier = new byte[32];
         byte[] anchor = new byte[32];

--- a/chainbase/src/main/java/org/tron/common/zksnark/JLibrustzcash.java
+++ b/chainbase/src/main/java/org/tron/common/zksnark/JLibrustzcash.java
@@ -29,7 +29,7 @@ import org.tron.core.exception.ZksnarkException;
 @Slf4j
 public class JLibrustzcash {
 
-  private static Librustzcash INSTANCE = LibrustzcashWrapper.getInstance();
+  private static final Librustzcash INSTANCE = LibrustzcashWrapper.getInstance();
 
   public static void librustzcashZip32XskMaster(Zip32XskMasterParams params) {
     INSTANCE.librustzcashZip32XskMaster(params.getData(), params.getSize(), params.getM_bytes());

--- a/framework/src/main/java/org/tron/core/services/RpcApiService.java
+++ b/framework/src/main/java/org/tron/core/services/RpcApiService.java
@@ -664,15 +664,21 @@ public class RpcApiService extends RpcService {
         StreamObserver<GrpcAPI.DecryptNotes> responseObserver) {
       long startNum = request.getStartBlockIndex();
       long endNum = request.getEndBlockIndex();
+      byte[] ivk = request.getIvk().toByteArray();
+      if (ivk.length != 32) {
+        responseObserver.onError(Status.INVALID_ARGUMENT
+            .withDescription("ivk must be 32 bytes").asRuntimeException());
+        return;
+      }
 
       try {
         DecryptNotes decryptNotes = wallet
-            .scanNoteByIvk(startNum, endNum, request.getIvk().toByteArray());
+            .scanNoteByIvk(startNum, endNum, ivk);
         responseObserver.onNext(decryptNotes);
+        responseObserver.onCompleted();
       } catch (BadItemException | ZksnarkException e) {
         responseObserver.onError(getRunTimeException(e));
       }
-      responseObserver.onCompleted();
     }
 
     @Override
@@ -680,18 +686,25 @@ public class RpcApiService extends RpcService {
         StreamObserver<GrpcAPI.DecryptNotesMarked> responseObserver) {
       long startNum = request.getStartBlockIndex();
       long endNum = request.getEndBlockIndex();
+      byte[] ivk = request.getIvk().toByteArray();
+      byte[] ak = request.getAk().toByteArray();
+      byte[] nk = request.getNk().toByteArray();
+      if (ivk.length != 32 || ak.length != 32 || nk.length != 32) {
+        responseObserver.onError(Status.INVALID_ARGUMENT
+            .withDescription("ivk, ak, nk must each be 32 bytes")
+            .asRuntimeException());
+        return;
+      }
 
       try {
         DecryptNotesMarked decryptNotes = wallet.scanAndMarkNoteByIvk(startNum, endNum,
-            request.getIvk().toByteArray(),
-            request.getAk().toByteArray(),
-            request.getNk().toByteArray());
+            ivk, ak, nk);
         responseObserver.onNext(decryptNotes);
+        responseObserver.onCompleted();
       } catch (BadItemException | ZksnarkException | InvalidProtocolBufferException
           | ItemNotFoundException e) {
         responseObserver.onError(getRunTimeException(e));
       }
-      responseObserver.onCompleted();
     }
 
     @Override
@@ -699,24 +712,30 @@ public class RpcApiService extends RpcService {
         StreamObserver<GrpcAPI.DecryptNotes> responseObserver) {
       long startNum = request.getStartBlockIndex();
       long endNum = request.getEndBlockIndex();
+      byte[] ovk = request.getOvk().toByteArray();
+      if (ovk.length != 32) {
+        responseObserver.onError(Status.INVALID_ARGUMENT
+            .withDescription("ovk must be 32 bytes").asRuntimeException());
+        return;
+      }
       try {
         DecryptNotes decryptNotes = wallet
-            .scanNoteByOvk(startNum, endNum, request.getOvk().toByteArray());
+            .scanNoteByOvk(startNum, endNum, ovk);
         responseObserver.onNext(decryptNotes);
+        responseObserver.onCompleted();
       } catch (BadItemException | ZksnarkException e) {
         responseObserver.onError(getRunTimeException(e));
       }
-      responseObserver.onCompleted();
     }
 
     @Override
     public void isSpend(NoteParameters request, StreamObserver<SpendResult> responseObserver) {
       try {
         responseObserver.onNext(wallet.isSpend(request));
+        responseObserver.onCompleted();
       } catch (Exception e) {
         responseObserver.onError(getRunTimeException(e));
       }
-      responseObserver.onCompleted();
     }
 
     @Override
@@ -728,17 +747,28 @@ public class RpcApiService extends RpcService {
       byte[] ivk = request.getIvk().toByteArray();
       byte[] ak = request.getAk().toByteArray();
       byte[] nk = request.getNk().toByteArray();
+      if (ivk.length != 32 || ak.length != 32 || nk.length != 32) {
+        responseObserver.onError(Status.INVALID_ARGUMENT
+            .withDescription("ivk, ak, nk must each be 32 bytes")
+            .asRuntimeException());
+        return;
+      }
+      if (contractAddress.length != 21) {
+        responseObserver.onError(Status.INVALID_ARGUMENT
+            .withDescription("contractAddress must be 21 bytes")
+            .asRuntimeException());
+        return;
+      }
       ProtocolStringList topicsList = request.getEventsList();
 
       try {
         responseObserver.onNext(
             wallet.scanShieldedTRC20NotesByIvk(startNum, endNum, contractAddress, ivk, ak, nk,
                 topicsList));
-
+        responseObserver.onCompleted();
       } catch (Exception e) {
         responseObserver.onError(getRunTimeException(e));
       }
-      responseObserver.onCompleted();
     }
 
     @Override
@@ -748,15 +778,26 @@ public class RpcApiService extends RpcService {
       long endNum = request.getEndBlockIndex();
       byte[] contractAddress = request.getShieldedTRC20ContractAddress().toByteArray();
       byte[] ovk = request.getOvk().toByteArray();
+      if (ovk.length != 32) {
+        responseObserver.onError(Status.INVALID_ARGUMENT
+            .withDescription("ovk must be 32 bytes").asRuntimeException());
+        return;
+      }
+      if (contractAddress.length != 21) {
+        responseObserver.onError(Status.INVALID_ARGUMENT
+            .withDescription("contractAddress must be 21 bytes")
+            .asRuntimeException());
+        return;
+      }
       ProtocolStringList topicList = request.getEventsList();
       try {
         responseObserver
             .onNext(wallet
                 .scanShieldedTRC20NotesByOvk(startNum, endNum, ovk, contractAddress, topicList));
+        responseObserver.onCompleted();
       } catch (Exception e) {
         responseObserver.onError(getRunTimeException(e));
       }
-      responseObserver.onCompleted();
     }
 
     @Override
@@ -2270,10 +2311,16 @@ public class RpcApiService extends RpcService {
         StreamObserver<GrpcAPI.DecryptNotes> responseObserver) {
       long startNum = request.getStartBlockIndex();
       long endNum = request.getEndBlockIndex();
+      byte[] ivk = request.getIvk().toByteArray();
+      if (ivk.length != 32) {
+        responseObserver.onError(Status.INVALID_ARGUMENT
+            .withDescription("ivk must be 32 bytes").asRuntimeException());
+        return;
+      }
 
       try {
         DecryptNotes decryptNotes = wallet
-            .scanNoteByIvk(startNum, endNum, request.getIvk().toByteArray());
+            .scanNoteByIvk(startNum, endNum, ivk);
         responseObserver.onNext(decryptNotes);
       } catch (BadItemException | ZksnarkException e) {
         responseObserver.onError(getRunTimeException(e));
@@ -2288,12 +2335,19 @@ public class RpcApiService extends RpcService {
         StreamObserver<GrpcAPI.DecryptNotesMarked> responseObserver) {
       long startNum = request.getStartBlockIndex();
       long endNum = request.getEndBlockIndex();
+      byte[] ivk = request.getIvk().toByteArray();
+      byte[] ak = request.getAk().toByteArray();
+      byte[] nk = request.getNk().toByteArray();
+      if (ivk.length != 32 || ak.length != 32 || nk.length != 32) {
+        responseObserver.onError(Status.INVALID_ARGUMENT
+            .withDescription("ivk, ak, nk must each be 32 bytes")
+            .asRuntimeException());
+        return;
+      }
 
       try {
         DecryptNotesMarked decryptNotes = wallet.scanAndMarkNoteByIvk(startNum, endNum,
-            request.getIvk().toByteArray(),
-            request.getAk().toByteArray(),
-            request.getNk().toByteArray());
+            ivk, ak, nk);
         responseObserver.onNext(decryptNotes);
       } catch (BadItemException | ZksnarkException | InvalidProtocolBufferException
           | ItemNotFoundException e) {
@@ -2308,10 +2362,16 @@ public class RpcApiService extends RpcService {
         StreamObserver<GrpcAPI.DecryptNotes> responseObserver) {
       long startNum = request.getStartBlockIndex();
       long endNum = request.getEndBlockIndex();
+      byte[] ovk = request.getOvk().toByteArray();
+      if (ovk.length != 32) {
+        responseObserver.onError(Status.INVALID_ARGUMENT
+            .withDescription("ovk must be 32 bytes").asRuntimeException());
+        return;
+      }
 
       try {
         DecryptNotes decryptNotes = wallet
-            .scanNoteByOvk(startNum, endNum, request.getOvk().toByteArray());
+            .scanNoteByOvk(startNum, endNum, ovk);
         responseObserver.onNext(decryptNotes);
       } catch (BadItemException | ZksnarkException e) {
         responseObserver.onError(getRunTimeException(e));
@@ -2414,13 +2474,25 @@ public class RpcApiService extends RpcService {
         StreamObserver<org.tron.api.GrpcAPI.DecryptNotesTRC20> responseObserver) {
       long startNum = request.getStartBlockIndex();
       long endNum = request.getEndBlockIndex();
+      byte[] contractAddress = request.getShieldedTRC20ContractAddress().toByteArray();
+      byte[] ivk = request.getIvk().toByteArray();
+      byte[] ak = request.getAk().toByteArray();
+      byte[] nk = request.getNk().toByteArray();
+      if (ivk.length != 32 || ak.length != 32 || nk.length != 32) {
+        responseObserver.onError(Status.INVALID_ARGUMENT
+            .withDescription("ivk, ak, nk must each be 32 bytes")
+            .asRuntimeException());
+        return;
+      }
+      if (contractAddress.length != 21) {
+        responseObserver.onError(Status.INVALID_ARGUMENT
+            .withDescription("contractAddress must be 21 bytes")
+            .asRuntimeException());
+        return;
+      }
       try {
         DecryptNotesTRC20 decryptNotes = wallet.scanShieldedTRC20NotesByIvk(startNum, endNum,
-            request.getShieldedTRC20ContractAddress().toByteArray(),
-            request.getIvk().toByteArray(),
-            request.getAk().toByteArray(),
-            request.getNk().toByteArray(),
-            request.getEventsList());
+            contractAddress, ivk, ak, nk, request.getEventsList());
         responseObserver.onNext(decryptNotes);
       } catch (BadItemException | ZksnarkException e) {
         responseObserver.onError(getRunTimeException(e));
@@ -2440,11 +2512,22 @@ public class RpcApiService extends RpcService {
         StreamObserver<org.tron.api.GrpcAPI.DecryptNotesTRC20> responseObserver) {
       long startNum = request.getStartBlockIndex();
       long endNum = request.getEndBlockIndex();
+      byte[] contractAddress = request.getShieldedTRC20ContractAddress().toByteArray();
+      byte[] ovk = request.getOvk().toByteArray();
+      if (ovk.length != 32) {
+        responseObserver.onError(Status.INVALID_ARGUMENT
+            .withDescription("ovk must be 32 bytes").asRuntimeException());
+        return;
+      }
+      if (contractAddress.length != 21) {
+        responseObserver.onError(Status.INVALID_ARGUMENT
+            .withDescription("contractAddress must be 21 bytes")
+            .asRuntimeException());
+        return;
+      }
       try {
         DecryptNotesTRC20 decryptNotes = wallet.scanShieldedTRC20NotesByOvk(startNum, endNum,
-            request.getOvk().toByteArray(),
-            request.getShieldedTRC20ContractAddress().toByteArray(),
-            request.getEventsList());
+            ovk, contractAddress, request.getEventsList());
         responseObserver.onNext(decryptNotes);
       } catch (Exception e) {
         responseObserver.onError(getRunTimeException(e));

--- a/framework/src/main/java/org/tron/core/services/http/ScanShieldedTRC20NotesByIvkServlet.java
+++ b/framework/src/main/java/org/tron/core/services/http/ScanShieldedTRC20NotesByIvkServlet.java
@@ -70,11 +70,30 @@ public class ScanShieldedTRC20NotesByIvkServlet extends RateLimiterServlet {
 
       String ak = request.getParameter("ak");
       String nk = request.getParameter("nk");
+      String events = request.getParameter("events");
+      IvkDecryptTRC20Parameters.Builder builder = IvkDecryptTRC20Parameters.newBuilder();
+      if (events != null && !events.isEmpty()) {
+        JSONArray eventsArray = JSONArray.parseArray(events);
+        for (int i = 0; i < eventsArray.size(); i++) {
+          builder.addEvents(eventsArray.getString(i));
+        }
+      }
+
+      byte[] contractAddressBytes = ByteArray.fromHexString(contractAddress);
+      byte[] ivkBytes = ByteArray.fromHexString(ivk);
+      byte[] akBytes = ByteArray.fromHexString(ak);
+      byte[] nkBytes = ByteArray.fromHexString(nk);
+      if (ivkBytes.length != 32 || akBytes.length != 32 || nkBytes.length != 32) {
+        throw new IllegalArgumentException("ivk, ak, nk must each be 32 bytes");
+      }
+      if (contractAddressBytes.length != 21) {
+        throw new IllegalArgumentException("contractAddress must be 21 bytes");
+      }
 
       GrpcAPI.DecryptNotesTRC20 notes = wallet
           .scanShieldedTRC20NotesByIvk(startNum, endNum,
-              ByteArray.fromHexString(contractAddress), ByteArray.fromHexString(ivk),
-              ByteArray.fromHexString(ak), ByteArray.fromHexString(nk), null);
+              contractAddressBytes, ivkBytes, akBytes, nkBytes,
+              builder.getEventsList());
       response.getWriter().println(convertOutput(notes, visible));
     } catch (Exception e) {
       Util.processError(e, response);

--- a/framework/src/main/java/org/tron/core/zen/ShieldedTRC20ParametersBuilder.java
+++ b/framework/src/main/java/org/tron/core/zen/ShieldedTRC20ParametersBuilder.java
@@ -251,6 +251,9 @@ public class ShieldedTRC20ParametersBuilder {
     ShieldedTRC20Parameters shieldedTRC20Parameters;
 
     long ctx = JLibrustzcash.librustzcashSaplingProvingCtxInit();
+    if (ctx == 0) {
+      throw new ZksnarkException("Failed to initialize proving context");
+    }
     try {
       switch (shieldedTRC20ParametersType) {
         case MINT:

--- a/framework/src/main/java/org/tron/core/zen/ZenTransactionBuilder.java
+++ b/framework/src/main/java/org/tron/core/zen/ZenTransactionBuilder.java
@@ -137,6 +137,9 @@ public class ZenTransactionBuilder {
   public TransactionCapsule build(boolean withAsk) throws ZksnarkException {
     TransactionCapsule transactionCapsule;
     long ctx = JLibrustzcash.librustzcashSaplingProvingCtxInit();
+    if (ctx == 0) {
+      throw new ZksnarkException("Failed to initialize proving context");
+    }
 
     try {
       // Create SpendDescriptions
@@ -176,8 +179,6 @@ public class ZenTransactionBuilder {
               bindingSig)
       );
       contractBuilder.setBindingSignature(ByteString.copyFrom(bindingSig));
-    } catch (ZksnarkException e) {
-      throw e;
     } finally {
       JLibrustzcash.librustzcashSaplingProvingCtxFree(ctx);
     }

--- a/framework/src/test/java/org/tron/core/services/RpcApiServicesTest.java
+++ b/framework/src/test/java/org/tron/core/services/RpcApiServicesTest.java
@@ -9,6 +9,8 @@ import com.google.protobuf.Any;
 import com.google.protobuf.ByteString;
 import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
+import io.grpc.Status;
+import io.grpc.StatusRuntimeException;
 import java.io.IOException;
 import java.util.Objects;
 import java.util.concurrent.ExecutorService;
@@ -493,9 +495,11 @@ public class RpcApiServicesTest {
 
   @Test
   public void testScanNoteByIvk() {
+    ByteString dummyKey32 = ByteString.copyFrom(new byte[32]);
     IvkDecryptParameters message = IvkDecryptParameters.newBuilder()
         .setStartBlockIndex(0)
         .setEndBlockIndex(1)
+        .setIvk(dummyKey32)
         .build();
     assertNotNull(blockingStubFull.scanNoteByIvk(message));
     assertNotNull(blockingStubSolidity.scanNoteByIvk(message));
@@ -504,9 +508,13 @@ public class RpcApiServicesTest {
 
   @Test
   public void testScanAndMarkNoteByIvk() {
+    ByteString dummyKey32 = ByteString.copyFrom(new byte[32]);
     IvkDecryptAndMarkParameters message = IvkDecryptAndMarkParameters.newBuilder()
         .setStartBlockIndex(0)
         .setEndBlockIndex(1)
+        .setIvk(dummyKey32)
+        .setAk(dummyKey32)
+        .setNk(dummyKey32)
         .build();
     assertNotNull(blockingStubFull.scanAndMarkNoteByIvk(message));
     assertNotNull(blockingStubSolidity.scanAndMarkNoteByIvk(message));
@@ -536,9 +544,15 @@ public class RpcApiServicesTest {
 
   @Test
   public void testScanShieldedTRC20NotesByIvk() {
+    ByteString dummyKey32 = ByteString.copyFrom(new byte[32]);
+    ByteString dummyAddr21 = ByteString.copyFrom(new byte[21]);
     IvkDecryptTRC20Parameters message = IvkDecryptTRC20Parameters.newBuilder()
         .setStartBlockIndex(1)
         .setEndBlockIndex(10)
+        .setIvk(dummyKey32)
+        .setAk(dummyKey32)
+        .setNk(dummyKey32)
+        .setShieldedTRC20ContractAddress(dummyAddr21)
         .build();
     assertNotNull(blockingStubFull.scanShieldedTRC20NotesByIvk(message));
     assertNotNull(blockingStubSolidity.scanShieldedTRC20NotesByIvk(message));
@@ -547,13 +561,84 @@ public class RpcApiServicesTest {
 
   @Test
   public void testScanShieldedTRC20NotesByOvk() {
+    ByteString dummyKey32 = ByteString.copyFrom(new byte[32]);
+    ByteString dummyAddr21 = ByteString.copyFrom(new byte[21]);
     OvkDecryptTRC20Parameters message = OvkDecryptTRC20Parameters.newBuilder()
         .setStartBlockIndex(1)
         .setEndBlockIndex(10)
+        .setOvk(dummyKey32)
+        .setShieldedTRC20ContractAddress(dummyAddr21)
         .build();
     assertNotNull(blockingStubFull.scanShieldedTRC20NotesByOvk(message));
     assertNotNull(blockingStubSolidity.scanShieldedTRC20NotesByOvk(message));
     assertNotNull(blockingStubPBFT.scanShieldedTRC20NotesByOvk(message));
+  }
+
+  @Test
+  public void testScanNoteByIvkRejectsInvalidLength() {
+    IvkDecryptParameters message = IvkDecryptParameters.newBuilder()
+        .setStartBlockIndex(0)
+        .setEndBlockIndex(1)
+        .setIvk(ByteString.copyFrom(new byte[31]))
+        .build();
+    try {
+      blockingStubFull.scanNoteByIvk(message);
+      Assert.fail("Expected INVALID_ARGUMENT");
+    } catch (StatusRuntimeException e) {
+      Assert.assertEquals(Status.Code.INVALID_ARGUMENT, e.getStatus().getCode());
+    }
+  }
+
+  @Test
+  public void testScanAndMarkNoteByIvkRejectsInvalidLength() {
+    ByteString dummyKey32 = ByteString.copyFrom(new byte[32]);
+    IvkDecryptAndMarkParameters message = IvkDecryptAndMarkParameters.newBuilder()
+        .setStartBlockIndex(0)
+        .setEndBlockIndex(1)
+        .setIvk(ByteString.copyFrom(new byte[31]))
+        .setAk(dummyKey32)
+        .setNk(dummyKey32)
+        .build();
+    try {
+      blockingStubFull.scanAndMarkNoteByIvk(message);
+      Assert.fail("Expected INVALID_ARGUMENT");
+    } catch (StatusRuntimeException e) {
+      Assert.assertEquals(Status.Code.INVALID_ARGUMENT, e.getStatus().getCode());
+    }
+  }
+
+  @Test
+  public void testScanShieldedTRC20NotesByIvkRejectsInvalidLength() {
+    IvkDecryptTRC20Parameters message = IvkDecryptTRC20Parameters.newBuilder()
+        .setStartBlockIndex(1)
+        .setEndBlockIndex(10)
+        .setIvk(ByteString.copyFrom(new byte[31]))
+        .setAk(ByteString.copyFrom(new byte[32]))
+        .setNk(ByteString.copyFrom(new byte[32]))
+        .setShieldedTRC20ContractAddress(ByteString.copyFrom(new byte[21]))
+        .build();
+    try {
+      blockingStubFull.scanShieldedTRC20NotesByIvk(message);
+      Assert.fail("Expected INVALID_ARGUMENT");
+    } catch (StatusRuntimeException e) {
+      Assert.assertEquals(Status.Code.INVALID_ARGUMENT, e.getStatus().getCode());
+    }
+  }
+
+  @Test
+  public void testScanShieldedTRC20NotesByOvkRejectsInvalidLength() {
+    OvkDecryptTRC20Parameters message = OvkDecryptTRC20Parameters.newBuilder()
+        .setStartBlockIndex(1)
+        .setEndBlockIndex(10)
+        .setOvk(ByteString.copyFrom(new byte[31]))
+        .setShieldedTRC20ContractAddress(ByteString.copyFrom(new byte[21]))
+        .build();
+    try {
+      blockingStubFull.scanShieldedTRC20NotesByOvk(message);
+      Assert.fail("Expected INVALID_ARGUMENT");
+    } catch (StatusRuntimeException e) {
+      Assert.assertEquals(Status.Code.INVALID_ARGUMENT, e.getStatus().getCode());
+    }
   }
 
   //  @Test


### PR DESCRIPTION
## Summary

- Fix ineffective timeout protection in `VerifyTransferProof` — `countDownLatch.await()` result was never checked, futures now cancelled on timeout
- Add verification/proving context zero-value checks in `VerifyMintProof`, `VerifyBurnProof`, and `ZenTransactionBuilder`
- Make `UNCOMMITTED` static initializer fail-fast instead of silently swallowing `ZksnarkException`
- Change `insertLeaves()` and precompiled contract exception paths to return `Pair.of(false, EMPTY_BYTE_ARRAY)` to distinguish execution failure from verification failure
- Remove no-op `catch (ZksnarkException e) { throw e; }` blocks in `SaplingCheckSpendTask`, `SaplingCheckOutputTask`, `SaplingCheckBingdingSig`, and `ZenTransactionBuilder`
- Make `JLibrustzcash.INSTANCE` final
- Add gRPC input validation for shielded API key parameters (ivk/ovk/ak/nk must be 32 bytes, contractAddress must be 21 bytes)
- Fix HTTP `ScanShieldedTRC20NotesByIvkServlet.doGet()` missing `events` parameter parsing

## Test plan

- [ ] Verify `./gradlew clean build -x test` passes
- [ ] Run shielded transaction related tests
- [ ] Verify gRPC endpoints reject invalid key lengths with `INVALID_ARGUMENT`
- [ ] Verify `ScanShieldedTRC20NotesByIvkServlet` GET with `events` parameter works consistently with POST

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardens shielded transaction safety and input validation across gRPC/HTTP and precompiles. Adds fail‑fast checks, proper completion semantics, and clear INVALID_ARGUMENT errors to prevent silent failures.

- **Bug Fixes**
  - `VerifyTransferProof`: enforce latch timeout and cancel futures on timeout.
  - gRPC: validate `ivk/ovk/ak/nk` (32 bytes) and `contractAddress` (21 bytes); return INVALID_ARGUMENT; call `onCompleted()` only on success.
  - HTTP `ScanShieldedTRC20NotesByIvk` GET: parse `events` query; validate key and address lengths.
  - Tests: add valid-length inputs and negative tests asserting INVALID_ARGUMENT.

- **Hardening**
  - Fail fast on zero/invalid zkSNARK contexts in `VerifyMintProof`, `VerifyBurnProof`, `ZenTransactionBuilder`, and `ShieldedTRC20ParametersBuilder`.
  - Precompiled contracts: execution failures return `Pair.of(false, EMPTY_BYTE_ARRAY)` to distinguish from verification failure.
  - `UNCOMMITTED` static init now throws on `ZksnarkException`; remove redundant rethrows; make `JLibrustzcash.INSTANCE` final.

<sup>Written for commit 305c6e4221e66fb31bc3e829ebbc32de73b3b78e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Hardened zkSNARK verification: clearer failure responses, canceled tasks on timeouts, stricter proving/verification init checks, and simplified verification task behavior.
  * Improved RPC/HTTP handlers: validate ivk/ovk/ak/nk and contract address lengths up front, return INVALID_ARGUMENT early, and emit completion only on success.

* **New Features**
  * Optional event filtering for shielded TRC20 note scans via an events query.

* **Tests**
  * Added tests asserting invalid-length inputs produce INVALID_ARGUMENT.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->