### PR TITLE
fix(chainbase): strengthen signature length validation

### DIFF
--- a/actuator/src/main/java/org/tron/core/utils/TransactionUtil.java
+++ b/actuator/src/main/java/org/tron/core/utils/TransactionUtil.java
@@ -225,7 +225,8 @@ public class TransactionUtil {
           List<ByteString> approveList = new ArrayList<>();
           long currentWeight = TransactionCapsule.checkWeight(permission, trx.getSignatureList(),
               Sha256Hash.hash(CommonParameter.getInstance()
-                  .isECKeyCryptoEngine(), trx.getRawData().toByteArray()), approveList, null);
+                  .isECKeyCryptoEngine(), trx.getRawData().toByteArray()), approveList,
+              chainBaseManager.getDynamicPropertiesStore());
           tswBuilder.addAllApprovedList(approveList);
           tswBuilder.setCurrentWeight(currentWeight);
         }

--- a/actuator/src/main/java/org/tron/core/utils/TransactionUtil.java
+++ b/actuator/src/main/java/org/tron/core/utils/TransactionUtil.java
@@ -225,7 +225,7 @@ public class TransactionUtil {
           List<ByteString> approveList = new ArrayList<>();
           long currentWeight = TransactionCapsule.checkWeight(permission, trx.getSignatureList(),
               Sha256Hash.hash(CommonParameter.getInstance()
-                  .isECKeyCryptoEngine(), trx.getRawData().toByteArray()), approveList);
+                  .isECKeyCryptoEngine(), trx.getRawData().toByteArray()), approveList, null);
           tswBuilder.addAllApprovedList(approveList);
           tswBuilder.setCurrentWeight(currentWeight);
         }

--- a/actuator/src/main/java/org/tron/core/utils/TransactionUtil.java
+++ b/actuator/src/main/java/org/tron/core/utils/TransactionUtil.java
@@ -223,10 +223,13 @@ public class TransactionUtil {
         tswBuilder.setPermission(permission);
         if (trx.getSignatureCount() > 0) {
           List<ByteString> approveList = new ArrayList<>();
+          // Read-only introspection: pass osakaAllowed=false so a historical tx
+          // committed pre-Osaka with a sig above MAX_SIGNATURE_SIZE is still
+          // resolvable; the upper bound only gates new submissions post-Osaka.
           long currentWeight = TransactionCapsule.checkWeight(permission, trx.getSignatureList(),
               Sha256Hash.hash(CommonParameter.getInstance()
                   .isECKeyCryptoEngine(), trx.getRawData().toByteArray()), approveList,
-              chainBaseManager.getDynamicPropertiesStore());
+              false);
           tswBuilder.addAllApprovedList(approveList);
           tswBuilder.setCurrentWeight(currentWeight);
         }

--- a/chainbase/src/main/java/org/tron/core/capsule/BlockCapsule.java
+++ b/chainbase/src/main/java/org/tron/core/capsule/BlockCapsule.java
@@ -186,9 +186,8 @@ public class BlockCapsule implements ProtoCapsule<Block> {
       AccountStore accountStore) throws ValidateSignatureException {
     try {
       ByteString witnessSig = block.getBlockHeader().getWitnessSignature();
-      if (witnessSig.size() < ChainConstant.MIN_SIGNATURE_SIZE
-          || (dynamicPropertiesStore.getAllowTvmOsaka() == 1
-          && witnessSig.size() > ChainConstant.MAX_SIGNATURE_SIZE)) {
+      if (!SignUtils.isValidLength(witnessSig.size(),
+          dynamicPropertiesStore.isAllowTvmOsaka())) {
         throw new ValidateSignatureException(
             "Witness signature size is " + witnessSig.size());
       }

--- a/chainbase/src/main/java/org/tron/core/capsule/BlockCapsule.java
+++ b/chainbase/src/main/java/org/tron/core/capsule/BlockCapsule.java
@@ -185,9 +185,14 @@ public class BlockCapsule implements ProtoCapsule<Block> {
   public boolean validateSignature(DynamicPropertiesStore dynamicPropertiesStore,
       AccountStore accountStore) throws ValidateSignatureException {
     try {
+      ByteString witnessSig = block.getBlockHeader().getWitnessSignature();
+      if (witnessSig.size() < 65 || (dynamicPropertiesStore.getAllowTvmOsaka() == 1
+          && witnessSig.size() != 65)) {
+        throw new ValidateSignatureException(
+            "Witness signature size is " + witnessSig.size());
+      }
       byte[] sigAddress = SignUtils.signatureToAddress(getRawHash().getBytes(),
-          TransactionCapsule.getBase64FromByteString(
-              block.getBlockHeader().getWitnessSignature()),
+          TransactionCapsule.getBase64FromByteString(witnessSig),
           CommonParameter.getInstance().isECKeyCryptoEngine());
       byte[] witnessAccountAddress = block.getBlockHeader().getRawData().getWitnessAddress()
           .toByteArray();

--- a/chainbase/src/main/java/org/tron/core/capsule/BlockCapsule.java
+++ b/chainbase/src/main/java/org/tron/core/capsule/BlockCapsule.java
@@ -187,7 +187,7 @@ public class BlockCapsule implements ProtoCapsule<Block> {
     try {
       ByteString witnessSig = block.getBlockHeader().getWitnessSignature();
       if (!SignUtils.isValidLength(witnessSig.size(),
-          dynamicPropertiesStore.isAllowTvmOsaka())) {
+          dynamicPropertiesStore.signatureMaxSizeChecked())) {
         throw new ValidateSignatureException(
             "Witness signature size is " + witnessSig.size());
       }

--- a/chainbase/src/main/java/org/tron/core/capsule/BlockCapsule.java
+++ b/chainbase/src/main/java/org/tron/core/capsule/BlockCapsule.java
@@ -186,8 +186,9 @@ public class BlockCapsule implements ProtoCapsule<Block> {
       AccountStore accountStore) throws ValidateSignatureException {
     try {
       ByteString witnessSig = block.getBlockHeader().getWitnessSignature();
-      if (witnessSig.size() < 65 || (dynamicPropertiesStore.getAllowTvmOsaka() == 1
-          && witnessSig.size() != 65)) {
+      if (witnessSig.size() < ChainConstant.MIN_SIGNATURE_SIZE
+          || (dynamicPropertiesStore.getAllowTvmOsaka() == 1
+          && witnessSig.size() > ChainConstant.MAX_SIGNATURE_SIZE)) {
         throw new ValidateSignatureException(
             "Witness signature size is " + witnessSig.size());
       }

--- a/chainbase/src/main/java/org/tron/core/capsule/TransactionCapsule.java
+++ b/chainbase/src/main/java/org/tron/core/capsule/TransactionCapsule.java
@@ -33,7 +33,6 @@ import java.security.SignatureException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
-import java.util.Objects;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
@@ -232,18 +231,7 @@ public class TransactionCapsule implements ProtoCapsule<Transaction> {
    *  @see ForkController#init(org.tron.core.ChainBaseManager)
    */
   public static long checkWeight(Permission permission, List<ByteString> sigs, byte[] hash,
-      List<ByteString> approveList, DynamicPropertiesStore dynamicPropertiesStore)
-      throws SignatureException, PermissionException, SignatureFormatException {
-    Objects.requireNonNull(dynamicPropertiesStore, "dynamicPropertiesStore");
-    return checkWeight(permission, sigs, hash, approveList,
-        dynamicPropertiesStore.isAllowTvmOsaka());
-  }
-
-  // Read-only callers (e.g. getTransactionSignWeight) should pass osakaAllowed=false
-  // so historical transactions with sigs above MAX_SIGNATURE_SIZE are still
-  // introspectable; the upper bound is meant to gate new submissions post-Osaka.
-  public static long checkWeight(Permission permission, List<ByteString> sigs, byte[] hash,
-      List<ByteString> approveList, boolean osakaAllowed)
+      List<ByteString> approveList, boolean checkMaxSignatureSize)
       throws SignatureException, PermissionException, SignatureFormatException {
     long currentWeight = 0;
     if (sigs.size() > permission.getKeysCount()) {
@@ -253,7 +241,7 @@ public class TransactionCapsule implements ProtoCapsule<Transaction> {
     }
     HashMap addMap = new HashMap();
     for (ByteString sig : sigs) {
-      if (!SignUtils.isValidLength(sig.size(), osakaAllowed)) {
+      if (!SignUtils.isValidLength(sig.size(), checkMaxSignatureSize)) {
         throw new SignatureFormatException("Signature size is " + sig.size());
       }
       String base64 = TransactionCapsule.getBase64FromByteString(sig);
@@ -500,7 +488,7 @@ public class TransactionCapsule implements ProtoCapsule<Transaction> {
     }
     checkPermission(permissionId, permission, contract);
     long weight = checkWeight(permission, transaction.getSignatureList(), hash, null,
-        dynamicPropertiesStore);
+        dynamicPropertiesStore.signatureMaxSizeChecked());
     if (weight >= permission.getThreshold()) {
       return true;
     }
@@ -618,7 +606,7 @@ public class TransactionCapsule implements ProtoCapsule<Transaction> {
     if (this.transaction.getSignatureCount() > 0) {
       checkWeight(permission, this.transaction.getSignatureList(),
           this.getTransactionId().getBytes(),
-          approveList, dynamicPropertiesStore);
+          approveList, dynamicPropertiesStore.signatureMaxSizeChecked());
       if (approveList.contains(ByteString.copyFrom(address))) {
         throw new PermissionException(encode58Check(address) + " had signed!");
       }

--- a/chainbase/src/main/java/org/tron/core/capsule/TransactionCapsule.java
+++ b/chainbase/src/main/java/org/tron/core/capsule/TransactionCapsule.java
@@ -230,7 +230,7 @@ public class TransactionCapsule implements ProtoCapsule<Transaction> {
    *  @see ForkController#init(org.tron.core.ChainBaseManager)
    */
   public static long checkWeight(Permission permission, List<ByteString> sigs, byte[] hash,
-      List<ByteString> approveList)
+      List<ByteString> approveList, DynamicPropertiesStore dynamicPropertiesStore)
       throws SignatureException, PermissionException, SignatureFormatException {
     long currentWeight = 0;
     if (sigs.size() > permission.getKeysCount()) {
@@ -240,7 +240,8 @@ public class TransactionCapsule implements ProtoCapsule<Transaction> {
     }
     HashMap addMap = new HashMap();
     for (ByteString sig : sigs) {
-      if (sig.size() < 65) {
+      if (sig.size() < 65 || (dynamicPropertiesStore != null
+          && dynamicPropertiesStore.getAllowTvmOsaka() == 1 && sig.size() != 65)) {
         throw new SignatureFormatException(
             "Signature size is " + sig.size());
       }
@@ -487,7 +488,8 @@ public class TransactionCapsule implements ProtoCapsule<Transaction> {
       throw new PermissionException("permission isn't exit");
     }
     checkPermission(permissionId, permission, contract);
-    long weight = checkWeight(permission, transaction.getSignatureList(), hash, null);
+    long weight = checkWeight(permission, transaction.getSignatureList(), hash, null,
+        dynamicPropertiesStore);
     if (weight >= permission.getThreshold()) {
       return true;
     }
@@ -604,7 +606,7 @@ public class TransactionCapsule implements ProtoCapsule<Transaction> {
     if (this.transaction.getSignatureCount() > 0) {
       checkWeight(permission, this.transaction.getSignatureList(),
           this.getTransactionId().getBytes(),
-          approveList);
+          approveList, null);
       if (approveList.contains(ByteString.copyFrom(address))) {
         throw new PermissionException(encode58Check(address) + " had signed!");
       }
@@ -620,8 +622,9 @@ public class TransactionCapsule implements ProtoCapsule<Transaction> {
         .signHash(getTransactionId().getBytes())));
     this.transaction = this.transaction.toBuilder().addSignature(sig).build();
   }
-  
-  private static void checkPermission(int permissionId, Permission permission, Transaction.Contract contract) throws PermissionException {
+
+  private static void checkPermission(int permissionId, Permission permission,
+      Transaction.Contract contract) throws PermissionException {
     if (permissionId != 0) {
       if (permission.getType() != PermissionType.Active) {
         throw new PermissionException("Permission type is error");
@@ -703,7 +706,7 @@ public class TransactionCapsule implements ProtoCapsule<Transaction> {
         }
       }
       isVerified = true;
-    }  
+    }
     return true;
   }
 

--- a/chainbase/src/main/java/org/tron/core/capsule/TransactionCapsule.java
+++ b/chainbase/src/main/java/org/tron/core/capsule/TransactionCapsule.java
@@ -55,6 +55,7 @@ import org.tron.common.utils.ReflectUtils;
 import org.tron.common.utils.Sha256Hash;
 import org.tron.core.actuator.TransactionFactory;
 import org.tron.core.config.Parameter;
+import org.tron.core.config.Parameter.ChainConstant;
 import org.tron.core.db.TransactionContext;
 import org.tron.core.db.TransactionTrace;
 import org.tron.core.exception.BadItemException;
@@ -242,8 +243,9 @@ public class TransactionCapsule implements ProtoCapsule<Transaction> {
     }
     HashMap addMap = new HashMap();
     for (ByteString sig : sigs) {
-      if (sig.size() < 65 || (dynamicPropertiesStore.getAllowTvmOsaka() == 1
-          && sig.size() != 65)) {
+      if (sig.size() < ChainConstant.MIN_SIGNATURE_SIZE
+          || (dynamicPropertiesStore.getAllowTvmOsaka() == 1
+          && sig.size() > ChainConstant.MAX_SIGNATURE_SIZE)) {
         throw new SignatureFormatException("Signature size is " + sig.size());
       }
       String base64 = TransactionCapsule.getBase64FromByteString(sig);

--- a/chainbase/src/main/java/org/tron/core/capsule/TransactionCapsule.java
+++ b/chainbase/src/main/java/org/tron/core/capsule/TransactionCapsule.java
@@ -33,6 +33,7 @@ import java.security.SignatureException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Objects;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
@@ -232,6 +233,7 @@ public class TransactionCapsule implements ProtoCapsule<Transaction> {
   public static long checkWeight(Permission permission, List<ByteString> sigs, byte[] hash,
       List<ByteString> approveList, DynamicPropertiesStore dynamicPropertiesStore)
       throws SignatureException, PermissionException, SignatureFormatException {
+    Objects.requireNonNull(dynamicPropertiesStore, "dynamicPropertiesStore");
     long currentWeight = 0;
     if (sigs.size() > permission.getKeysCount()) {
       throw new PermissionException(
@@ -240,10 +242,9 @@ public class TransactionCapsule implements ProtoCapsule<Transaction> {
     }
     HashMap addMap = new HashMap();
     for (ByteString sig : sigs) {
-      if (sig.size() < 65 || (dynamicPropertiesStore != null
-          && dynamicPropertiesStore.getAllowTvmOsaka() == 1 && sig.size() != 65)) {
-        throw new SignatureFormatException(
-            "Signature size is " + sig.size());
+      if (sig.size() < 65 || (dynamicPropertiesStore.getAllowTvmOsaka() == 1
+          && sig.size() != 65)) {
+        throw new SignatureFormatException("Signature size is " + sig.size());
       }
       String base64 = TransactionCapsule.getBase64FromByteString(sig);
       byte[] address = SignUtils
@@ -585,7 +586,8 @@ public class TransactionCapsule implements ProtoCapsule<Transaction> {
     this.transaction = this.transaction.toBuilder().addSignature(sig).build();
   }
 
-  public void addSign(byte[] privateKey, AccountStore accountStore)
+  public void addSign(byte[] privateKey, AccountStore accountStore,
+      DynamicPropertiesStore dynamicPropertiesStore)
       throws PermissionException, SignatureException, SignatureFormatException {
     Transaction.Contract contract = this.transaction.getRawData().getContract(0);
     int permissionId = contract.getPermissionId();
@@ -606,7 +608,7 @@ public class TransactionCapsule implements ProtoCapsule<Transaction> {
     if (this.transaction.getSignatureCount() > 0) {
       checkWeight(permission, this.transaction.getSignatureList(),
           this.getTransactionId().getBytes(),
-          approveList, null);
+          approveList, dynamicPropertiesStore);
       if (approveList.contains(ByteString.copyFrom(address))) {
         throw new PermissionException(encode58Check(address) + " had signed!");
       }

--- a/chainbase/src/main/java/org/tron/core/capsule/TransactionCapsule.java
+++ b/chainbase/src/main/java/org/tron/core/capsule/TransactionCapsule.java
@@ -235,6 +235,16 @@ public class TransactionCapsule implements ProtoCapsule<Transaction> {
       List<ByteString> approveList, DynamicPropertiesStore dynamicPropertiesStore)
       throws SignatureException, PermissionException, SignatureFormatException {
     Objects.requireNonNull(dynamicPropertiesStore, "dynamicPropertiesStore");
+    return checkWeight(permission, sigs, hash, approveList,
+        dynamicPropertiesStore.isAllowTvmOsaka());
+  }
+
+  // Read-only callers (e.g. getTransactionSignWeight) should pass osakaAllowed=false
+  // so historical transactions with sigs above MAX_SIGNATURE_SIZE are still
+  // introspectable; the upper bound is meant to gate new submissions post-Osaka.
+  public static long checkWeight(Permission permission, List<ByteString> sigs, byte[] hash,
+      List<ByteString> approveList, boolean osakaAllowed)
+      throws SignatureException, PermissionException, SignatureFormatException {
     long currentWeight = 0;
     if (sigs.size() > permission.getKeysCount()) {
       throw new PermissionException(
@@ -243,9 +253,7 @@ public class TransactionCapsule implements ProtoCapsule<Transaction> {
     }
     HashMap addMap = new HashMap();
     for (ByteString sig : sigs) {
-      if (sig.size() < ChainConstant.MIN_SIGNATURE_SIZE
-          || (dynamicPropertiesStore.getAllowTvmOsaka() == 1
-          && sig.size() > ChainConstant.MAX_SIGNATURE_SIZE)) {
+      if (!SignUtils.isValidLength(sig.size(), osakaAllowed)) {
         throw new SignatureFormatException("Signature size is " + sig.size());
       }
       String base64 = TransactionCapsule.getBase64FromByteString(sig);

--- a/chainbase/src/main/java/org/tron/core/store/DynamicPropertiesStore.java
+++ b/chainbase/src/main/java/org/tron/core/store/DynamicPropertiesStore.java
@@ -3011,7 +3011,7 @@ public class DynamicPropertiesStore extends TronStoreWithRevoking<BytesCapsule> 
     this.put(ALLOW_TVM_OSAKA, new BytesCapsule(ByteArray.fromLong(value)));
   }
 
-  public boolean isAllowTvmOsaka() {
+  public boolean signatureMaxSizeChecked() {
     return getAllowTvmOsaka() == 1L;
   }
 

--- a/chainbase/src/main/java/org/tron/core/store/DynamicPropertiesStore.java
+++ b/chainbase/src/main/java/org/tron/core/store/DynamicPropertiesStore.java
@@ -3011,6 +3011,10 @@ public class DynamicPropertiesStore extends TronStoreWithRevoking<BytesCapsule> 
     this.put(ALLOW_TVM_OSAKA, new BytesCapsule(ByteArray.fromLong(value)));
   }
 
+  public boolean isAllowTvmOsaka() {
+    return getAllowTvmOsaka() == 1L;
+  }
+
   public long getAllowTvmPrague() {
     return Optional.ofNullable(getUnchecked(ALLOW_TVM_PRAGUE))
         .map(BytesCapsule::getData)

--- a/common/src/main/java/org/tron/core/config/Parameter.java
+++ b/common/src/main/java/org/tron/core/config/Parameter.java
@@ -69,6 +69,8 @@ public class Parameter {
     public static final int MAX_VOTE_NUMBER = 30;
     public static final int SOLIDIFIED_THRESHOLD = 70; // 70%
     public static final int PRIVATE_KEY_LENGTH = 64;
+    public static final int MIN_SIGNATURE_SIZE = 65;
+    public static final int MAX_SIGNATURE_SIZE = 68;
     public static final int BLOCK_SIZE = 2_000_000;
     public static final long CLOCK_MAX_DELAY = 3600000; // 3600 * 1000 ms
     public static final int BLOCK_PRODUCE_TIMEOUT_PERCENT = 50; // 50%

--- a/common/src/main/java/org/tron/core/config/Parameter.java
+++ b/common/src/main/java/org/tron/core/config/Parameter.java
@@ -70,6 +70,9 @@ public class Parameter {
     public static final int SOLIDIFIED_THRESHOLD = 70; // 70%
     public static final int PRIVATE_KEY_LENGTH = 64;
     public static final int MIN_SIGNATURE_SIZE = 65;
+    // Canonical ECDSA signature is 65 bytes (r||s||v). 68 = 65 + up to 3 trailing
+    // padding bytes; this window accommodates historical non-canonical encodings
+    // observed on chain. Long-term goal is to tighten this back to a strict 65.
     public static final int MAX_SIGNATURE_SIZE = 68;
     public static final int BLOCK_SIZE = 2_000_000;
     public static final long CLOCK_MAX_DELAY = 3600000; // 3600 * 1000 ms

--- a/consensus/src/main/java/org/tron/consensus/pbft/PbftMessageHandle.java
+++ b/consensus/src/main/java/org/tron/consensus/pbft/PbftMessageHandle.java
@@ -129,7 +129,7 @@ public class PbftMessageHandle {
       PbftMessage paMessage = message.buildPrePareMessage(miner);
       forwardMessage(paMessage);
       try {
-        paMessage.analyzeSignature();
+        paMessage.analyzeSignature(chainBaseManager.getDynamicPropertiesStore());
       } catch (SignatureException e) {
         logger.error("", e);
       }
@@ -175,7 +175,7 @@ public class PbftMessageHandle {
           doneMsg.put(message.getNo(), cmMessage);
           forwardMessage(cmMessage);
           try {
-            cmMessage.analyzeSignature();
+            cmMessage.analyzeSignature(chainBaseManager.getDynamicPropertiesStore());
           } catch (SignatureException e) {
             logger.error("", e);
           }

--- a/consensus/src/main/java/org/tron/consensus/pbft/message/PbftBaseMessage.java
+++ b/consensus/src/main/java/org/tron/consensus/pbft/message/PbftBaseMessage.java
@@ -7,12 +7,12 @@ import java.security.SignatureException;
 import java.util.stream.Collectors;
 import org.bouncycastle.util.encoders.Hex;
 import org.tron.common.crypto.ECKey;
+import org.tron.common.crypto.SignUtils;
 import org.tron.common.overlay.message.Message;
 import org.tron.common.utils.ByteUtil;
 import org.tron.common.utils.Sha256Hash;
 import org.tron.common.utils.StringUtil;
 import org.tron.core.capsule.TransactionCapsule;
-import org.tron.core.config.Parameter.ChainConstant;
 import org.tron.core.exception.P2pException;
 import org.tron.core.store.DynamicPropertiesStore;
 import org.tron.protos.Protocol.PBFTMessage;
@@ -100,9 +100,8 @@ public abstract class PbftBaseMessage extends Message {
   public void analyzeSignature(DynamicPropertiesStore dynamicPropertiesStore)
       throws SignatureException {
     ByteString signature = getPbftMessage().getSignature();
-    if (signature.size() < ChainConstant.MIN_SIGNATURE_SIZE
-        || (dynamicPropertiesStore.getAllowTvmOsaka() == 1
-        && signature.size() > ChainConstant.MAX_SIGNATURE_SIZE)) {
+    if (!SignUtils.isValidLength(signature.size(),
+        dynamicPropertiesStore.isAllowTvmOsaka())) {
       throw new SignatureException("PBFT signature size is " + signature.size());
     }
     byte[] hash = Sha256Hash.hash(true, getPbftMessage().getRawData().toByteArray());

--- a/consensus/src/main/java/org/tron/consensus/pbft/message/PbftBaseMessage.java
+++ b/consensus/src/main/java/org/tron/consensus/pbft/message/PbftBaseMessage.java
@@ -12,6 +12,7 @@ import org.tron.common.utils.ByteUtil;
 import org.tron.common.utils.Sha256Hash;
 import org.tron.common.utils.StringUtil;
 import org.tron.core.capsule.TransactionCapsule;
+import org.tron.core.config.Parameter.ChainConstant;
 import org.tron.core.exception.P2pException;
 import org.tron.core.store.DynamicPropertiesStore;
 import org.tron.protos.Protocol.PBFTMessage;
@@ -99,8 +100,9 @@ public abstract class PbftBaseMessage extends Message {
   public void analyzeSignature(DynamicPropertiesStore dynamicPropertiesStore)
       throws SignatureException {
     ByteString signature = getPbftMessage().getSignature();
-    if (signature.size() < 65 || (dynamicPropertiesStore.getAllowTvmOsaka() == 1
-        && signature.size() != 65)) {
+    if (signature.size() < ChainConstant.MIN_SIGNATURE_SIZE
+        || (dynamicPropertiesStore.getAllowTvmOsaka() == 1
+        && signature.size() > ChainConstant.MAX_SIGNATURE_SIZE)) {
       throw new SignatureException("PBFT signature size is " + signature.size());
     }
     byte[] hash = Sha256Hash.hash(true, getPbftMessage().getRawData().toByteArray());

--- a/consensus/src/main/java/org/tron/consensus/pbft/message/PbftBaseMessage.java
+++ b/consensus/src/main/java/org/tron/consensus/pbft/message/PbftBaseMessage.java
@@ -1,5 +1,6 @@
 package org.tron.consensus.pbft.message;
 
+import com.google.protobuf.ByteString;
 import com.google.protobuf.InvalidProtocolBufferException;
 import java.io.IOException;
 import java.security.SignatureException;
@@ -12,6 +13,7 @@ import org.tron.common.utils.Sha256Hash;
 import org.tron.common.utils.StringUtil;
 import org.tron.core.capsule.TransactionCapsule;
 import org.tron.core.exception.P2pException;
+import org.tron.core.store.DynamicPropertiesStore;
 import org.tron.protos.Protocol.PBFTMessage;
 import org.tron.protos.Protocol.PBFTMessage.DataType;
 import org.tron.protos.Protocol.SRL;
@@ -94,10 +96,16 @@ public abstract class PbftBaseMessage extends Message {
 
   public abstract String getNo();
 
-  public void analyzeSignature() throws SignatureException {
+  public void analyzeSignature(DynamicPropertiesStore dynamicPropertiesStore)
+      throws SignatureException {
+    ByteString signature = getPbftMessage().getSignature();
+    if (signature.size() < 65 || (dynamicPropertiesStore.getAllowTvmOsaka() == 1
+        && signature.size() != 65)) {
+      throw new SignatureException("PBFT signature size is " + signature.size());
+    }
     byte[] hash = Sha256Hash.hash(true, getPbftMessage().getRawData().toByteArray());
     publicKey = ECKey.signatureToAddress(hash, TransactionCapsule
-        .getBase64FromByteString(getPbftMessage().getSignature()));
+        .getBase64FromByteString(signature));
   }
 
   @Override

--- a/consensus/src/main/java/org/tron/consensus/pbft/message/PbftBaseMessage.java
+++ b/consensus/src/main/java/org/tron/consensus/pbft/message/PbftBaseMessage.java
@@ -101,7 +101,7 @@ public abstract class PbftBaseMessage extends Message {
       throws SignatureException {
     ByteString signature = getPbftMessage().getSignature();
     if (!SignUtils.isValidLength(signature.size(),
-        dynamicPropertiesStore.isAllowTvmOsaka())) {
+        dynamicPropertiesStore.signatureMaxSizeChecked())) {
       throw new SignatureException("PBFT signature size is " + signature.size());
     }
     byte[] hash = Sha256Hash.hash(true, getPbftMessage().getRawData().toByteArray());

--- a/crypto/src/main/java/org/tron/common/crypto/SignUtils.java
+++ b/crypto/src/main/java/org/tron/common/crypto/SignUtils.java
@@ -5,8 +5,14 @@ import java.security.SignatureException;
 import org.tron.common.crypto.ECKey.ECDSASignature;
 import org.tron.common.crypto.sm2.SM2;
 import org.tron.common.crypto.sm2.SM2.SM2Signature;
+import org.tron.core.config.Parameter.ChainConstant;
 
 public class SignUtils {
+
+  public static boolean isValidLength(int size, boolean osakaAllowed) {
+    return size >= ChainConstant.MIN_SIGNATURE_SIZE
+        && (!osakaAllowed || size <= ChainConstant.MAX_SIGNATURE_SIZE);
+  }
 
   public static SignInterface getGeneratedRandomSign(
       SecureRandom secureRandom, boolean isECKeyCryptoEngine) {

--- a/crypto/src/main/java/org/tron/common/crypto/SignUtils.java
+++ b/crypto/src/main/java/org/tron/common/crypto/SignUtils.java
@@ -9,9 +9,9 @@ import org.tron.core.config.Parameter.ChainConstant;
 
 public class SignUtils {
 
-  public static boolean isValidLength(int size, boolean osakaAllowed) {
+  public static boolean isValidLength(int size, boolean checkMaxSignatureSize) {
     return size >= ChainConstant.MIN_SIGNATURE_SIZE
-        && (!osakaAllowed || size <= ChainConstant.MAX_SIGNATURE_SIZE);
+        && (!checkMaxSignatureSize || size <= ChainConstant.MAX_SIGNATURE_SIZE);
   }
 
   public static SignInterface getGeneratedRandomSign(

--- a/framework/src/main/java/org/tron/core/Wallet.java
+++ b/framework/src/main/java/org/tron/core/Wallet.java
@@ -645,10 +645,8 @@ public class Wallet {
           byte[] hash = Sha256Hash.hash(CommonParameter
               .getInstance().isECKeyCryptoEngine(), trx.getRawData().toByteArray());
           for (ByteString sig : trx.getSignatureList()) {
-            // Read-only introspection: only enforce the lower bound so a tx
-            // committed pre-Osaka with a sig above MAX_SIGNATURE_SIZE is still
-            // resolvable; the upper bound only gates new submissions post-Osaka.
-            if (sig.size() < ChainConstant.MIN_SIGNATURE_SIZE) {
+            // Read-only path: skip the upper bound so historical txs stay resolvable.
+            if (!SignUtils.isValidLength(sig.size(), false)) {
               throw new SignatureFormatException(
                   "Signature size is " + sig.size());
             }

--- a/framework/src/main/java/org/tron/core/Wallet.java
+++ b/framework/src/main/java/org/tron/core/Wallet.java
@@ -645,9 +645,10 @@ public class Wallet {
           byte[] hash = Sha256Hash.hash(CommonParameter
               .getInstance().isECKeyCryptoEngine(), trx.getRawData().toByteArray());
           for (ByteString sig : trx.getSignatureList()) {
-            if (sig.size() < ChainConstant.MIN_SIGNATURE_SIZE
-                || (chainBaseManager.getDynamicPropertiesStore().getAllowTvmOsaka() == 1
-                && sig.size() > ChainConstant.MAX_SIGNATURE_SIZE)) {
+            // Read-only introspection: only enforce the lower bound so a tx
+            // committed pre-Osaka with a sig above MAX_SIGNATURE_SIZE is still
+            // resolvable; the upper bound only gates new submissions post-Osaka.
+            if (sig.size() < ChainConstant.MIN_SIGNATURE_SIZE) {
               throw new SignatureFormatException(
                   "Signature size is " + sig.size());
             }

--- a/framework/src/main/java/org/tron/core/Wallet.java
+++ b/framework/src/main/java/org/tron/core/Wallet.java
@@ -644,7 +644,8 @@ public class Wallet {
           byte[] hash = Sha256Hash.hash(CommonParameter
               .getInstance().isECKeyCryptoEngine(), trx.getRawData().toByteArray());
           for (ByteString sig : trx.getSignatureList()) {
-            if (sig.size() < 65) {
+            if (sig.size() < 65 || (chainBaseManager.getDynamicPropertiesStore()
+                .getAllowTvmOsaka() == 1 && sig.size() != 65)) {
               throw new SignatureFormatException(
                   "Signature size is " + sig.size());
             }

--- a/framework/src/main/java/org/tron/core/Wallet.java
+++ b/framework/src/main/java/org/tron/core/Wallet.java
@@ -160,6 +160,7 @@ import org.tron.core.capsule.TransactionResultCapsule;
 import org.tron.core.capsule.VotesCapsule;
 import org.tron.core.capsule.WitnessCapsule;
 import org.tron.core.capsule.utils.MarketUtils;
+import org.tron.core.config.Parameter.ChainConstant;
 import org.tron.core.config.args.Args;
 import org.tron.core.db.BandwidthProcessor;
 import org.tron.core.db.BlockIndexStore;
@@ -644,8 +645,9 @@ public class Wallet {
           byte[] hash = Sha256Hash.hash(CommonParameter
               .getInstance().isECKeyCryptoEngine(), trx.getRawData().toByteArray());
           for (ByteString sig : trx.getSignatureList()) {
-            if (sig.size() < 65 || (chainBaseManager.getDynamicPropertiesStore()
-                .getAllowTvmOsaka() == 1 && sig.size() != 65)) {
+            if (sig.size() < ChainConstant.MIN_SIGNATURE_SIZE
+                || (chainBaseManager.getDynamicPropertiesStore().getAllowTvmOsaka() == 1
+                && sig.size() > ChainConstant.MAX_SIGNATURE_SIZE)) {
               throw new SignatureFormatException(
                   "Signature size is " + sig.size());
             }

--- a/framework/src/main/java/org/tron/core/net/messagehandler/PbftDataSyncHandler.java
+++ b/framework/src/main/java/org/tron/core/net/messagehandler/PbftDataSyncHandler.java
@@ -19,6 +19,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.tron.common.crypto.ECKey;
+import org.tron.common.crypto.SignUtils;
 import org.tron.common.es.ExecutorServiceManager;
 import org.tron.common.utils.ByteArray;
 import org.tron.common.utils.Sha256Hash;
@@ -26,7 +27,6 @@ import org.tron.consensus.base.Param;
 import org.tron.core.ChainBaseManager;
 import org.tron.core.capsule.BlockCapsule;
 import org.tron.core.capsule.TransactionCapsule;
-import org.tron.core.config.Parameter.ChainConstant;
 import org.tron.core.db.PbftSignDataStore;
 import org.tron.core.exception.P2pException;
 import org.tron.core.net.message.TronMessage;
@@ -123,31 +123,28 @@ public class PbftDataSyncHandler implements TronMsgHandler, Closeable {
   private boolean validPbftSign(Raw raw, List<ByteString> srSignList,
       List<ByteString> currentSrList) {
     //valid sr list
+    if (srSignList.size() < Param.getInstance().getAgreeNodeCount()) {
+      return false;
+    }
     if (srSignList.size() != 0) {
-      Set<ByteString> srSignSet = new ConcurrentSet();
-      srSignSet.addAll(srSignList);
-      if (srSignSet.size() < Param.getInstance().getAgreeNodeCount()) {
-        logger.error("sr sign count {} < sr count * 2/3 + 1 == {}", srSignSet.size(),
-            Param.getInstance().getAgreeNodeCount());
-        return false;
-      }
       byte[] dataHash = Sha256Hash.hash(true, raw.toByteArray());
       Set<ByteString> srSet = Sets.newHashSet(currentSrList);
+      Set<ByteString> validSrAddressSet = new ConcurrentSet();
       List<Future<Boolean>> futureList = new ArrayList<>();
       for (ByteString sign : srSignList) {
         futureList.add(executorService.submit(
-            new ValidPbftSignTask(raw.getViewN(), srSignSet, dataHash, srSet, sign)));
+            new ValidPbftSignTask(raw.getViewN(), validSrAddressSet, dataHash, srSet, sign)));
       }
       for (Future<Boolean> future : futureList) {
         try {
-          if (!future.get()) {
-            return false;
-          }
+          future.get();
         } catch (Exception e) {
           logger.error("", e);
         }
       }
-      if (srSignSet.size() != 0) {
+      if (validSrAddressSet.size() < Param.getInstance().getAgreeNodeCount()) {
+        logger.error("sr sign count {} < sr count * 2/3 + 1 == {}", validSrAddressSet.size(),
+            Param.getInstance().getAgreeNodeCount());
         return false;
       }
     }
@@ -157,15 +154,15 @@ public class PbftDataSyncHandler implements TronMsgHandler, Closeable {
   private class ValidPbftSignTask implements Callable<Boolean> {
 
     private long viewN;
-    private Set<ByteString> srSignSet;
+    private Set<ByteString> validSrAddressSet;
     private byte[] dataHash;
     private Set<ByteString> srSet;
     private ByteString sign;
 
-    ValidPbftSignTask(long viewN, Set<ByteString> srSignSet,
+    ValidPbftSignTask(long viewN, Set<ByteString> validSrAddressSet,
         byte[] dataHash, Set<ByteString> srSet, ByteString sign) {
       this.viewN = viewN;
-      this.srSignSet = srSignSet;
+      this.validSrAddressSet = validSrAddressSet;
       this.dataHash = dataHash;
       this.srSet = srSet;
       this.sign = sign;
@@ -174,10 +171,10 @@ public class PbftDataSyncHandler implements TronMsgHandler, Closeable {
     @Override
     public Boolean call() throws Exception {
       try {
-        if (sign.size() < ChainConstant.MIN_SIGNATURE_SIZE
-            || (chainBaseManager.getDynamicPropertiesStore().getAllowTvmOsaka() == 1
-            && sign.size() > ChainConstant.MAX_SIGNATURE_SIZE)) {
-          throw new SignatureException("PBFT signature size is " + sign.size());
+        if (!SignUtils.isValidLength(sign.size(),
+            chainBaseManager.getDynamicPropertiesStore().isAllowTvmOsaka())) {
+          logger.error("viewN {} pbft signature size {} is invalid", viewN, sign.size());
+          return false;
         }
         byte[] srAddress = ECKey.signatureToAddress(dataHash,
             TransactionCapsule.getBase64FromByteString(sign));
@@ -186,7 +183,7 @@ public class PbftDataSyncHandler implements TronMsgHandler, Closeable {
               ByteArray.toHexString(srAddress));
           return false;
         }
-        srSignSet.remove(sign);
+        validSrAddressSet.add(ByteString.copyFrom(srAddress));
       } catch (SignatureException e) {
         logger.error("viewN {} valid sr list sign fail!", viewN, e);
         return false;

--- a/framework/src/main/java/org/tron/core/net/messagehandler/PbftDataSyncHandler.java
+++ b/framework/src/main/java/org/tron/core/net/messagehandler/PbftDataSyncHandler.java
@@ -26,6 +26,7 @@ import org.tron.consensus.base.Param;
 import org.tron.core.ChainBaseManager;
 import org.tron.core.capsule.BlockCapsule;
 import org.tron.core.capsule.TransactionCapsule;
+import org.tron.core.config.Parameter.ChainConstant;
 import org.tron.core.db.PbftSignDataStore;
 import org.tron.core.exception.P2pException;
 import org.tron.core.net.message.TronMessage;
@@ -173,9 +174,9 @@ public class PbftDataSyncHandler implements TronMsgHandler, Closeable {
     @Override
     public Boolean call() throws Exception {
       try {
-        if (sign.size() < 65
+        if (sign.size() < ChainConstant.MIN_SIGNATURE_SIZE
             || (chainBaseManager.getDynamicPropertiesStore().getAllowTvmOsaka() == 1
-            && sign.size() != 65)) {
+            && sign.size() > ChainConstant.MAX_SIGNATURE_SIZE)) {
           throw new SignatureException("PBFT signature size is " + sign.size());
         }
         byte[] srAddress = ECKey.signatureToAddress(dataHash,

--- a/framework/src/main/java/org/tron/core/net/messagehandler/PbftDataSyncHandler.java
+++ b/framework/src/main/java/org/tron/core/net/messagehandler/PbftDataSyncHandler.java
@@ -173,6 +173,11 @@ public class PbftDataSyncHandler implements TronMsgHandler, Closeable {
     @Override
     public Boolean call() throws Exception {
       try {
+        if (sign.size() < 65
+            || (chainBaseManager.getDynamicPropertiesStore().getAllowTvmOsaka() == 1
+            && sign.size() != 65)) {
+          throw new SignatureException("PBFT signature size is " + sign.size());
+        }
         byte[] srAddress = ECKey.signatureToAddress(dataHash,
             TransactionCapsule.getBase64FromByteString(sign));
         if (!srSet.contains(ByteString.copyFrom(srAddress))) {

--- a/framework/src/main/java/org/tron/core/net/messagehandler/PbftDataSyncHandler.java
+++ b/framework/src/main/java/org/tron/core/net/messagehandler/PbftDataSyncHandler.java
@@ -172,7 +172,7 @@ public class PbftDataSyncHandler implements TronMsgHandler, Closeable {
     public Boolean call() throws Exception {
       try {
         if (!SignUtils.isValidLength(sign.size(),
-            chainBaseManager.getDynamicPropertiesStore().isAllowTvmOsaka())) {
+            chainBaseManager.getDynamicPropertiesStore().signatureMaxSizeChecked())) {
           logger.error("viewN {} pbft signature size {} is invalid", viewN, sign.size());
           return false;
         }

--- a/framework/src/main/java/org/tron/core/net/messagehandler/PbftMsgHandler.java
+++ b/framework/src/main/java/org/tron/core/net/messagehandler/PbftMsgHandler.java
@@ -11,6 +11,7 @@ import org.tron.consensus.base.Param;
 import org.tron.consensus.pbft.PbftManager;
 import org.tron.consensus.pbft.message.PbftBaseMessage;
 import org.tron.consensus.pbft.message.PbftMessage;
+import org.tron.core.ChainBaseManager;
 import org.tron.core.config.args.Args;
 import org.tron.core.exception.P2pException;
 import org.tron.core.net.TronNetDelegate;
@@ -32,6 +33,9 @@ public class PbftMsgHandler {
   @Autowired
   private TronNetDelegate tronNetDelegate;
 
+  @Autowired
+  private ChainBaseManager chainBaseManager;
+
   public void processMessage(PeerConnection peer, PbftMessage msg) throws Exception {
     if (!tronNetDelegate.allowPBFT()) {
       return;
@@ -50,7 +54,7 @@ public class PbftMsgHandler {
         && currentEpoch - msg.getEpoch() > expireEpoch) {
       return;
     }
-    msg.analyzeSignature();
+    msg.analyzeSignature(chainBaseManager.getDynamicPropertiesStore());
     String key = buildKey(msg);
     Lock lock = striped.get(key);
     try {

--- a/framework/src/main/java/org/tron/core/net/service/relay/RelayService.java
+++ b/framework/src/main/java/org/tron/core/net/service/relay/RelayService.java
@@ -154,7 +154,9 @@ public class RelayService {
     try {
       ByteString signature = msg.getSignature();
       if (!SignUtils.isValidLength(signature.size(),
-          chainBaseManager.getDynamicPropertiesStore().isAllowTvmOsaka())) {
+          chainBaseManager.getDynamicPropertiesStore().signatureMaxSizeChecked())) {
+        logger.warn("HelloMessage from {}, signature size {} is invalid.",
+            channel.getInetAddress(), signature.size());
         return false;
       }
       Sha256Hash hash = Sha256Hash.of(CommonParameter

--- a/framework/src/main/java/org/tron/core/net/service/relay/RelayService.java
+++ b/framework/src/main/java/org/tron/core/net/service/relay/RelayService.java
@@ -24,6 +24,7 @@ import org.tron.common.utils.ByteArray;
 import org.tron.common.utils.Sha256Hash;
 import org.tron.core.ChainBaseManager;
 import org.tron.core.capsule.TransactionCapsule;
+import org.tron.core.config.Parameter.ChainConstant;
 import org.tron.core.config.args.Args;
 import org.tron.core.db.Manager;
 import org.tron.core.net.TronNetDelegate;
@@ -153,8 +154,9 @@ public class RelayService {
     boolean flag;
     try {
       ByteString signature = msg.getSignature();
-      if (signature.size() < 65 || (chainBaseManager.getDynamicPropertiesStore()
-          .getAllowTvmOsaka() == 1 && signature.size() != 65)) {
+      if (signature.size() < ChainConstant.MIN_SIGNATURE_SIZE
+          || (chainBaseManager.getDynamicPropertiesStore().getAllowTvmOsaka() == 1
+          && signature.size() > ChainConstant.MAX_SIGNATURE_SIZE)) {
         return false;
       }
       Sha256Hash hash = Sha256Hash.of(CommonParameter

--- a/framework/src/main/java/org/tron/core/net/service/relay/RelayService.java
+++ b/framework/src/main/java/org/tron/core/net/service/relay/RelayService.java
@@ -24,7 +24,6 @@ import org.tron.common.utils.ByteArray;
 import org.tron.common.utils.Sha256Hash;
 import org.tron.core.ChainBaseManager;
 import org.tron.core.capsule.TransactionCapsule;
-import org.tron.core.config.Parameter.ChainConstant;
 import org.tron.core.config.args.Args;
 import org.tron.core.db.Manager;
 import org.tron.core.net.TronNetDelegate;
@@ -154,9 +153,8 @@ public class RelayService {
     boolean flag;
     try {
       ByteString signature = msg.getSignature();
-      if (signature.size() < ChainConstant.MIN_SIGNATURE_SIZE
-          || (chainBaseManager.getDynamicPropertiesStore().getAllowTvmOsaka() == 1
-          && signature.size() > ChainConstant.MAX_SIGNATURE_SIZE)) {
+      if (!SignUtils.isValidLength(signature.size(),
+          chainBaseManager.getDynamicPropertiesStore().isAllowTvmOsaka())) {
         return false;
       }
       Sha256Hash hash = Sha256Hash.of(CommonParameter

--- a/framework/src/main/java/org/tron/core/net/service/relay/RelayService.java
+++ b/framework/src/main/java/org/tron/core/net/service/relay/RelayService.java
@@ -152,10 +152,15 @@ public class RelayService {
 
     boolean flag;
     try {
+      ByteString signature = msg.getSignature();
+      if (signature.size() < 65 || (chainBaseManager.getDynamicPropertiesStore()
+          .getAllowTvmOsaka() == 1 && signature.size() != 65)) {
+        return false;
+      }
       Sha256Hash hash = Sha256Hash.of(CommonParameter
           .getInstance().isECKeyCryptoEngine(), ByteArray.fromLong(msg.getTimestamp()));
       String sig =
-          TransactionCapsule.getBase64FromByteString(msg.getSignature());
+          TransactionCapsule.getBase64FromByteString(signature);
       byte[] sigAddress = SignUtils.signatureToAddress(hash.getBytes(), sig,
           Args.getInstance().isECKeyCryptoEngine());
       if (manager.getDynamicPropertiesStore().getAllowMultiSign() != 1) {

--- a/framework/src/test/java/org/tron/common/utils/client/utils/TransactionUtils.java
+++ b/framework/src/test/java/org/tron/common/utils/client/utils/TransactionUtils.java
@@ -32,6 +32,7 @@ import org.tron.core.exception.PermissionException;
 import org.tron.core.exception.SignatureFormatException;
 import org.tron.core.services.http.JsonFormat;
 import org.tron.core.store.AccountStore;
+import org.tron.core.store.DynamicPropertiesStore;
 import org.tron.protos.Protocol.Transaction;
 import org.tron.protos.Protocol.Transaction.Contract;
 import org.tron.protos.contract.AccountContract.AccountCreateContract;
@@ -193,11 +194,12 @@ public class TransactionUtils {
   }
 
   public static TransactionCapsule addTransactionSign(Transaction transaction, String priKey,
-                                               AccountStore accountStore)
+                                               AccountStore accountStore,
+                                               DynamicPropertiesStore dynamicPropertiesStore)
           throws PermissionException, SignatureException, SignatureFormatException {
     byte[] privateKey = ByteArray.fromHexString(priKey);
     TransactionCapsule trx = new TransactionCapsule(transaction);
-    trx.addSign(privateKey, accountStore);
+    trx.addSign(privateKey, accountStore, dynamicPropertiesStore);
     return trx;
   }
 

--- a/framework/src/test/java/org/tron/core/actuator/ShieldedTransferActuatorTest.java
+++ b/framework/src/test/java/org/tron/core/actuator/ShieldedTransferActuatorTest.java
@@ -207,7 +207,8 @@ public class ShieldedTransferActuatorTest extends BaseTest {
 
       //Add public address sign
       transactionCap = TransactionUtils.addTransactionSign(transactionCap.getInstance(),
-              ADDRESS_ONE_PRIVATE_KEY, dbManager.getAccountStore());
+              ADDRESS_ONE_PRIVATE_KEY, dbManager.getAccountStore(),
+          dbManager.getDynamicPropertiesStore());
 
       Assert.assertTrue(dbManager.pushTransaction(transactionCap));
     } catch (Exception e) {
@@ -235,7 +236,8 @@ public class ShieldedTransferActuatorTest extends BaseTest {
 
       //Add public address sign
       transactionCap = TransactionUtils.addTransactionSign(transactionCap.getInstance(),
-              ADDRESS_ONE_PRIVATE_KEY, dbManager.getAccountStore());
+              ADDRESS_ONE_PRIVATE_KEY, dbManager.getAccountStore(),
+          dbManager.getDynamicPropertiesStore());
 
       Assert.assertTrue(dbManager.pushTransaction(transactionCap));
     } catch (Exception e) {
@@ -255,7 +257,7 @@ public class ShieldedTransferActuatorTest extends BaseTest {
 
       //Add public address sign
       TransactionUtils.addTransactionSign(transactionCap.getInstance(), ADDRESS_TWO_PRIVATE_KEY,
-              dbManager.getAccountStore());
+              dbManager.getAccountStore(), dbManager.getDynamicPropertiesStore());
       Assert.assertTrue(false);
     } catch (PermissionException e) {
       Assert.assertTrue(e instanceof PermissionException);
@@ -395,7 +397,8 @@ public class ShieldedTransferActuatorTest extends BaseTest {
       TransactionCapsule transactionCap = getPublicToShieldedTransaction();
       //Add public address sign
       transactionCap = TransactionUtils.addTransactionSign(transactionCap.getInstance(),
-              ADDRESS_ONE_PRIVATE_KEY, dbManager.getAccountStore());
+              ADDRESS_ONE_PRIVATE_KEY, dbManager.getAccountStore(),
+          dbManager.getDynamicPropertiesStore());
 
       AccountCapsule accountCapsule =
           dbManager.getAccountStore().get(ByteArray.fromHexString(PUBLIC_ADDRESS_ONE));
@@ -983,7 +986,8 @@ public class ShieldedTransferActuatorTest extends BaseTest {
 
       //Add public address sign
       transactionCapOne = TransactionUtils.addTransactionSign(transactionCapOne.getInstance(),
-              ADDRESS_ONE_PRIVATE_KEY, dbManager.getAccountStore());
+              ADDRESS_ONE_PRIVATE_KEY, dbManager.getAccountStore(),
+          dbManager.getDynamicPropertiesStore());
 
       Assert.assertTrue(dbManager.pushTransaction(transactionCapOne));
       AccountCapsule accountCapsuleOne =
@@ -1403,4 +1407,3 @@ public class ShieldedTransferActuatorTest extends BaseTest {
     }
   }
 }
-

--- a/framework/src/test/java/org/tron/core/actuator/utils/TransactionUtilTest.java
+++ b/framework/src/test/java/org/tron/core/actuator/utils/TransactionUtilTest.java
@@ -468,7 +468,7 @@ public class TransactionUtilTest extends BaseTest {
         .setOwnerAddress(ByteString.copyFrom(owner))
         .setToAddress(ByteString.copyFrom(new byte[21]))
         .build();
-    byte[] paddedSig = new byte[66];
+    byte[] paddedSig = new byte[69];
     paddedSig[64] = 27;
     Transaction transaction = new TransactionCapsule(
         transferContract, ContractType.TransferContract)

--- a/framework/src/test/java/org/tron/core/actuator/utils/TransactionUtilTest.java
+++ b/framework/src/test/java/org/tron/core/actuator/utils/TransactionUtilTest.java
@@ -461,7 +461,36 @@ public class TransactionUtilTest extends BaseTest {
   }
 
   @Test
-  public void getTransactionSignWeightPaddedSigOsakaRejected() {
+  public void getTransactionSignWeightShortSigRejected() {
+    // Lower bound is enforced on the read-only path; upper bound is not
+    // (so a tx committed pre-Osaka with a padded sig stays introspectable).
+    byte[] owner = ByteArray.fromHexString(OWNER_ADDRESS);
+    TransferContract transferContract = TransferContract.newBuilder()
+        .setAmount(1L)
+        .setOwnerAddress(ByteString.copyFrom(owner))
+        .setToAddress(ByteString.copyFrom(new byte[21]))
+        .build();
+    Transaction transaction = new TransactionCapsule(
+        transferContract, ContractType.TransferContract)
+        .getInstance().toBuilder()
+        .addSignature(ByteString.copyFrom(new byte[64]))
+        .build();
+
+    dbManager.getDynamicPropertiesStore().saveAllowTvmOsaka(1);
+    try {
+      TransactionSignWeight signWeight = transactionUtil.getTransactionSignWeight(transaction);
+      Assert.assertEquals(response_code.SIGNATURE_FORMAT_ERROR,
+          signWeight.getResult().getCode());
+    } finally {
+      dbManager.getDynamicPropertiesStore().saveAllowTvmOsaka(0);
+    }
+  }
+
+  @Test
+  public void getTransactionSignWeightPaddedSigPostOsakaAccepted() {
+    // Read-only path must not reject a 69-byte signature post-Osaka — the
+    // upper bound is meant to gate new submissions, not block introspection
+    // of historical transactions.
     byte[] owner = ByteArray.fromHexString(OWNER_ADDRESS);
     TransferContract transferContract = TransferContract.newBuilder()
         .setAmount(1L)
@@ -479,7 +508,7 @@ public class TransactionUtilTest extends BaseTest {
     dbManager.getDynamicPropertiesStore().saveAllowTvmOsaka(1);
     try {
       TransactionSignWeight signWeight = transactionUtil.getTransactionSignWeight(transaction);
-      Assert.assertEquals(response_code.SIGNATURE_FORMAT_ERROR,
+      Assert.assertNotEquals(response_code.SIGNATURE_FORMAT_ERROR,
           signWeight.getResult().getCode());
     } finally {
       dbManager.getDynamicPropertiesStore().saveAllowTvmOsaka(0);

--- a/framework/src/test/java/org/tron/core/actuator/utils/TransactionUtilTest.java
+++ b/framework/src/test/java/org/tron/core/actuator/utils/TransactionUtilTest.java
@@ -17,11 +17,14 @@ import com.google.protobuf.ByteString;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
+import javax.annotation.Resource;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.tron.api.GrpcAPI.TransactionSignWeight;
+import org.tron.api.GrpcAPI.TransactionSignWeight.Result.response_code;
 import org.tron.common.BaseTest;
 import org.tron.common.TestConstants;
 import org.tron.common.utils.ByteArray;
@@ -38,11 +41,15 @@ import org.tron.protos.Protocol.AccountType;
 import org.tron.protos.Protocol.Transaction;
 import org.tron.protos.Protocol.Transaction.Contract.ContractType;
 import org.tron.protos.contract.BalanceContract.DelegateResourceContract;
+import org.tron.protos.contract.BalanceContract.TransferContract;
 
 @Slf4j(topic = "capsule")
 public class TransactionUtilTest extends BaseTest {
 
   private static String OWNER_ADDRESS;
+
+  @Resource
+  private TransactionUtil transactionUtil;
 
   /**
    * Init .
@@ -451,5 +458,31 @@ public class TransactionUtilTest extends BaseTest {
       threadList.get(i).join();
     }
     Assert.assertTrue(true);
+  }
+
+  @Test
+  public void getTransactionSignWeightPaddedSigOsakaRejected() {
+    byte[] owner = ByteArray.fromHexString(OWNER_ADDRESS);
+    TransferContract transferContract = TransferContract.newBuilder()
+        .setAmount(1L)
+        .setOwnerAddress(ByteString.copyFrom(owner))
+        .setToAddress(ByteString.copyFrom(new byte[21]))
+        .build();
+    byte[] paddedSig = new byte[66];
+    paddedSig[64] = 27;
+    Transaction transaction = new TransactionCapsule(
+        transferContract, ContractType.TransferContract)
+        .getInstance().toBuilder()
+        .addSignature(ByteString.copyFrom(paddedSig))
+        .build();
+
+    dbManager.getDynamicPropertiesStore().saveAllowTvmOsaka(1);
+    try {
+      TransactionSignWeight signWeight = transactionUtil.getTransactionSignWeight(transaction);
+      Assert.assertEquals(response_code.SIGNATURE_FORMAT_ERROR,
+          signWeight.getResult().getCode());
+    } finally {
+      dbManager.getDynamicPropertiesStore().saveAllowTvmOsaka(0);
+    }
   }
 }

--- a/framework/src/test/java/org/tron/core/capsule/BlockCapsuleTest.java
+++ b/framework/src/test/java/org/tron/core/capsule/BlockCapsuleTest.java
@@ -221,11 +221,10 @@ public class BlockCapsuleTest {
     return block;
   }
 
-  private BlockCapsule withPaddedWitnessSig(BlockCapsule src) {
+  private BlockCapsule withPaddedWitnessSig(BlockCapsule src, int extraBytes) {
     byte[] original = src.getInstance().getBlockHeader()
         .getWitnessSignature().toByteArray();
-    // append one extra zero byte
-    byte[] padded = Arrays.copyOf(original, original.length + 1);
+    byte[] padded = Arrays.copyOf(original, original.length + extraBytes);
     Block modified = src.getInstance().toBuilder()
         .setBlockHeader(src.getInstance().getBlockHeader().toBuilder()
             .setWitnessSignature(ByteString.copyFrom(padded)))
@@ -235,12 +234,13 @@ public class BlockCapsuleTest {
 
   @Test
   public void witnessSignaturePaddedOsakaRejected() throws Exception {
-    BlockCapsule paddedBlock = withPaddedWitnessSig(signedBlock());
-    Assert.assertEquals(66,
+    // Pad past MAX_SIGNATURE_SIZE (68) so the post-Osaka upper-bound check fires.
+    BlockCapsule paddedBlock = withPaddedWitnessSig(signedBlock(), 4);
+    Assert.assertEquals(69,
         paddedBlock.getInstance().getBlockHeader().getWitnessSignature().size());
 
     DynamicPropertiesStore dps = mock(DynamicPropertiesStore.class);
-    when(dps.getAllowTvmOsaka()).thenReturn(1L);
+    when(dps.isAllowTvmOsaka()).thenReturn(true);
     AccountStore accountStore = mock(AccountStore.class);
 
     try {
@@ -248,16 +248,16 @@ public class BlockCapsuleTest {
       Assert.fail("Expected ValidateSignatureException for padded witness sig post-Osaka");
     } catch (ValidateSignatureException e) {
       Assert.assertTrue("Error must mention the sig size",
-          e.getMessage().contains("66"));
+          e.getMessage().contains("69"));
     }
   }
 
   @Test
   public void witnessSignaturePaddedPreOsaka() throws Exception {
-    BlockCapsule paddedBlock = withPaddedWitnessSig(signedBlock());
+    BlockCapsule paddedBlock = withPaddedWitnessSig(signedBlock(), 4);
 
     DynamicPropertiesStore dps = mock(DynamicPropertiesStore.class);
-    when(dps.getAllowTvmOsaka()).thenReturn(0L);
+    when(dps.isAllowTvmOsaka()).thenReturn(false);
     when(dps.getAllowMultiSign()).thenReturn(0L);
     AccountStore accountStore = mock(AccountStore.class);
 

--- a/framework/src/test/java/org/tron/core/capsule/BlockCapsuleTest.java
+++ b/framework/src/test/java/org/tron/core/capsule/BlockCapsuleTest.java
@@ -240,16 +240,14 @@ public class BlockCapsuleTest {
         paddedBlock.getInstance().getBlockHeader().getWitnessSignature().size());
 
     DynamicPropertiesStore dps = mock(DynamicPropertiesStore.class);
-    when(dps.isAllowTvmOsaka()).thenReturn(true);
+    when(dps.signatureMaxSizeChecked()).thenReturn(true);
     AccountStore accountStore = mock(AccountStore.class);
 
-    try {
-      paddedBlock.validateSignature(dps, accountStore);
-      Assert.fail("Expected ValidateSignatureException for padded witness sig post-Osaka");
-    } catch (ValidateSignatureException e) {
-      Assert.assertTrue("Error must mention the sig size",
-          e.getMessage().contains("69"));
-    }
+    ValidateSignatureException e = Assert.assertThrows(
+        ValidateSignatureException.class,
+        () -> paddedBlock.validateSignature(dps, accountStore));
+    Assert.assertTrue("Error must mention the sig size",
+        e.getMessage().contains("69"));
   }
 
   @Test
@@ -257,7 +255,7 @@ public class BlockCapsuleTest {
     BlockCapsule paddedBlock = withPaddedWitnessSig(signedBlock(), 4);
 
     DynamicPropertiesStore dps = mock(DynamicPropertiesStore.class);
-    when(dps.isAllowTvmOsaka()).thenReturn(false);
+    when(dps.signatureMaxSizeChecked()).thenReturn(false);
     when(dps.getAllowMultiSign()).thenReturn(0L);
     AccountStore accountStore = mock(AccountStore.class);
 

--- a/framework/src/test/java/org/tron/core/capsule/BlockCapsuleTest.java
+++ b/framework/src/test/java/org/tron/core/capsule/BlockCapsuleTest.java
@@ -1,5 +1,8 @@
 package org.tron.core.capsule;
 
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
 import com.google.protobuf.ByteString;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -21,6 +24,10 @@ import org.tron.core.Wallet;
 import org.tron.core.config.args.Args;
 import org.tron.core.exception.BadBlockException;
 import org.tron.core.exception.BadItemException;
+import org.tron.core.exception.ValidateSignatureException;
+import org.tron.core.store.AccountStore;
+import org.tron.core.store.DynamicPropertiesStore;
+import org.tron.protos.Protocol.Block;
 import org.tron.protos.Protocol.Transaction.Contract.ContractType;
 import org.tron.protos.contract.BalanceContract.TransferContract;
 
@@ -194,6 +201,88 @@ public class BlockCapsuleTest {
       threadList.get(i).join();
     }
     Assert.assertTrue(true);
+  }
+
+  // ---- witness signature size enforcement tests ----
+
+  private BlockCapsule signedBlock() {
+    String key = PublicMethod.getRandomPrivateKey();
+    LocalWitnesses lw = new LocalWitnesses();
+    lw.setPrivateKeys(Arrays.asList(key));
+    lw.initWitnessAccountAddress(null, true);
+    Args.setLocalWitnesses(lw);
+
+    BlockCapsule block = new BlockCapsule(2,
+        Sha256Hash.wrap(ByteString.copyFrom(ByteArray.fromHexString(
+            "9938a342238077182498b464ac0292229938a342238077182498b464ac029222"))),
+        9999L,
+        ByteString.copyFrom(lw.getWitnessAccountAddress()));
+    block.sign(ByteArray.fromHexString(key));
+    return block;
+  }
+
+  private BlockCapsule withPaddedWitnessSig(BlockCapsule src) {
+    byte[] original = src.getInstance().getBlockHeader()
+        .getWitnessSignature().toByteArray();
+    // append one extra zero byte
+    byte[] padded = Arrays.copyOf(original, original.length + 1);
+    Block modified = src.getInstance().toBuilder()
+        .setBlockHeader(src.getInstance().getBlockHeader().toBuilder()
+            .setWitnessSignature(ByteString.copyFrom(padded)))
+        .build();
+    return new BlockCapsule(modified);
+  }
+
+  @Test
+  public void witnessSignaturePaddedOsakaRejected() throws Exception {
+    BlockCapsule paddedBlock = withPaddedWitnessSig(signedBlock());
+    Assert.assertEquals(66,
+        paddedBlock.getInstance().getBlockHeader().getWitnessSignature().size());
+
+    DynamicPropertiesStore dps = mock(DynamicPropertiesStore.class);
+    when(dps.getAllowTvmOsaka()).thenReturn(1L);
+    AccountStore accountStore = mock(AccountStore.class);
+
+    try {
+      paddedBlock.validateSignature(dps, accountStore);
+      Assert.fail("Expected ValidateSignatureException for padded witness sig post-Osaka");
+    } catch (ValidateSignatureException e) {
+      Assert.assertTrue("Error must mention the sig size",
+          e.getMessage().contains("66"));
+    }
+  }
+
+  @Test
+  public void witnessSignaturePaddedPreOsaka() throws Exception {
+    BlockCapsule paddedBlock = withPaddedWitnessSig(signedBlock());
+
+    DynamicPropertiesStore dps = mock(DynamicPropertiesStore.class);
+    when(dps.getAllowTvmOsaka()).thenReturn(0L);
+    when(dps.getAllowMultiSign()).thenReturn(0L);
+    AccountStore accountStore = mock(AccountStore.class);
+
+    try {
+      paddedBlock.validateSignature(dps, accountStore);
+      // valid result is fine
+    } catch (ValidateSignatureException e) {
+      Assert.assertFalse("Size check must not fire before Osaka",
+          e.getMessage().contains("Witness signature size"));
+    }
+  }
+
+  @Test(expected = ValidateSignatureException.class)
+  public void witnessSignatureShortRejected() throws Exception {
+    Block modified = blockCapsule0.getInstance().toBuilder()
+        .setBlockHeader(blockCapsule0.getInstance().getBlockHeader().toBuilder()
+            .setWitnessSignature(ByteString.copyFrom(new byte[64])))
+        .build();
+    BlockCapsule shortBlock = new BlockCapsule(modified);
+
+    DynamicPropertiesStore dps = mock(DynamicPropertiesStore.class);
+    when(dps.getAllowTvmOsaka()).thenReturn(0L);
+    AccountStore accountStore = mock(AccountStore.class);
+
+    shortBlock.validateSignature(dps, accountStore);
   }
 
 }

--- a/framework/src/test/java/org/tron/core/capsule/TransactionCapsuleTest.java
+++ b/framework/src/test/java/org/tron/core/capsule/TransactionCapsuleTest.java
@@ -9,6 +9,7 @@ import ch.qos.logback.classic.Logger;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.read.ListAppender;
 import com.google.protobuf.ByteString;
+import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
@@ -23,7 +24,11 @@ import org.tron.common.TestConstants;
 import org.tron.common.utils.StringUtil;
 import org.tron.core.Wallet;
 import org.tron.core.config.args.Args;
+import org.tron.core.exception.SignatureFormatException;
 import org.tron.protos.Protocol.AccountType;
+import org.tron.protos.Protocol.Key;
+import org.tron.protos.Protocol.Permission;
+import org.tron.protos.Protocol.Permission.PermissionType;
 import org.tron.protos.Protocol.Transaction;
 import org.tron.protos.Protocol.Transaction.Contract.ContractType;
 import org.tron.protos.Protocol.Transaction.Result;
@@ -132,6 +137,82 @@ public class TransactionCapsuleTest extends BaseTest {
       appender.stop();
       capsuleLogger.detachAppender(appender);
       capsuleLogger.setLevel(originalLevel);
+    }
+  }
+
+  // ---- checkWeight signature-size enforcement tests ----
+
+  private static final byte[] DUMMY_HASH = new byte[32];
+
+  private static Permission singleKeyPermission() {
+    return Permission.newBuilder()
+        .setType(PermissionType.Owner)
+        .setThreshold(1)
+        .addKeys(Key.newBuilder()
+            .setAddress(ByteString.copyFrom(new byte[21]))
+            .setWeight(1))
+        .build();
+  }
+
+  @Test(expected = SignatureFormatException.class)
+  public void checkWeightShortSigRejected() throws Exception {
+    List<ByteString> sigs = Collections.singletonList(ByteString.copyFrom(new byte[64]));
+    TransactionCapsule.checkWeight(singleKeyPermission(), sigs, DUMMY_HASH, null, null);
+  }
+
+  @Test(expected = SignatureFormatException.class)
+  public void checkWeightPaddedSigOsakaRejected() throws Exception {
+    dbManager.getDynamicPropertiesStore().saveAllowTvmOsaka(1);
+    try {
+      List<ByteString> sigs = Collections.singletonList(ByteString.copyFrom(new byte[66]));
+      TransactionCapsule.checkWeight(singleKeyPermission(), sigs, DUMMY_HASH, null,
+          dbManager.getDynamicPropertiesStore());
+    } finally {
+      dbManager.getDynamicPropertiesStore().saveAllowTvmOsaka(0);
+    }
+  }
+
+  @Test
+  public void checkWeightPaddedSigPreOsaka() {
+    dbManager.getDynamicPropertiesStore().saveAllowTvmOsaka(0);
+    List<ByteString> sigs = Collections.singletonList(ByteString.copyFrom(new byte[66]));
+    try {
+      TransactionCapsule.checkWeight(singleKeyPermission(), sigs, DUMMY_HASH, null,
+          dbManager.getDynamicPropertiesStore());
+    } catch (SignatureFormatException e) {
+      Assert.fail("Padded sig must not be rejected by size check before Osaka: " + e.getMessage());
+    } catch (Exception e) {
+      // SignatureException / PermissionException after the size check — expected
+    }
+  }
+
+  @Test
+  public void checkWeightPaddedSigNullDs() {
+    List<ByteString> sigs = Collections.singletonList(ByteString.copyFrom(new byte[66]));
+    try {
+      TransactionCapsule.checkWeight(singleKeyPermission(), sigs, DUMMY_HASH, null, null);
+    } catch (SignatureFormatException e) {
+      Assert.fail("Padded sig must not be rejected when DS is null: " + e.getMessage());
+    } catch (Exception e) {
+      // other exceptions after the size check — expected
+    }
+  }
+
+  @Test
+  public void checkWeightNormalSigOsaka() {
+    dbManager.getDynamicPropertiesStore().saveAllowTvmOsaka(1);
+    try {
+      byte[] validSizeSig = new byte[65];
+      validSizeSig[64] = 27; // v = 27 (valid range)
+      List<ByteString> sigs = Collections.singletonList(ByteString.copyFrom(validSizeSig));
+      TransactionCapsule.checkWeight(singleKeyPermission(), sigs, DUMMY_HASH, null,
+          dbManager.getDynamicPropertiesStore());
+    } catch (SignatureFormatException e) {
+      Assert.fail("65-byte sig must not be rejected by size check post-Osaka: " + e.getMessage());
+    } catch (Exception e) {
+      // crypto / permission error after size check — expected
+    } finally {
+      dbManager.getDynamicPropertiesStore().saveAllowTvmOsaka(0);
     }
   }
 }

--- a/framework/src/test/java/org/tron/core/capsule/TransactionCapsuleTest.java
+++ b/framework/src/test/java/org/tron/core/capsule/TransactionCapsuleTest.java
@@ -158,7 +158,7 @@ public class TransactionCapsuleTest extends BaseTest {
   public void checkWeightShortSigRejected() throws Exception {
     List<ByteString> sigs = Collections.singletonList(ByteString.copyFrom(new byte[64]));
     TransactionCapsule.checkWeight(singleKeyPermission(), sigs, DUMMY_HASH, null,
-        dbManager.getDynamicPropertiesStore());
+        dbManager.getDynamicPropertiesStore().signatureMaxSizeChecked());
   }
 
   @Test(expected = SignatureFormatException.class)
@@ -167,7 +167,7 @@ public class TransactionCapsuleTest extends BaseTest {
     try {
       List<ByteString> sigs = Collections.singletonList(ByteString.copyFrom(new byte[69]));
       TransactionCapsule.checkWeight(singleKeyPermission(), sigs, DUMMY_HASH, null,
-          dbManager.getDynamicPropertiesStore());
+          dbManager.getDynamicPropertiesStore().signatureMaxSizeChecked());
     } finally {
       dbManager.getDynamicPropertiesStore().saveAllowTvmOsaka(0);
     }
@@ -179,18 +179,12 @@ public class TransactionCapsuleTest extends BaseTest {
     List<ByteString> sigs = Collections.singletonList(ByteString.copyFrom(new byte[69]));
     try {
       TransactionCapsule.checkWeight(singleKeyPermission(), sigs, DUMMY_HASH, null,
-          dbManager.getDynamicPropertiesStore());
+          dbManager.getDynamicPropertiesStore().signatureMaxSizeChecked());
     } catch (SignatureFormatException e) {
       Assert.fail("Padded sig must not be rejected by size check before Osaka: " + e.getMessage());
     } catch (Exception e) {
       // SignatureException / PermissionException after the size check — expected
     }
-  }
-
-  @Test(expected = NullPointerException.class)
-  public void checkWeightNullDynamicPropertiesStoreRejected() throws Exception {
-    List<ByteString> sigs = Collections.singletonList(ByteString.copyFrom(new byte[65]));
-    TransactionCapsule.checkWeight(singleKeyPermission(), sigs, DUMMY_HASH, null, null);
   }
 
   @Test
@@ -201,7 +195,7 @@ public class TransactionCapsuleTest extends BaseTest {
       validSizeSig[64] = 27; // v = 27 (valid range)
       List<ByteString> sigs = Collections.singletonList(ByteString.copyFrom(validSizeSig));
       TransactionCapsule.checkWeight(singleKeyPermission(), sigs, DUMMY_HASH, null,
-          dbManager.getDynamicPropertiesStore());
+          dbManager.getDynamicPropertiesStore().signatureMaxSizeChecked());
     } catch (SignatureFormatException e) {
       Assert.fail("65-byte sig must not be rejected by size check post-Osaka: " + e.getMessage());
     } catch (Exception e) {

--- a/framework/src/test/java/org/tron/core/capsule/TransactionCapsuleTest.java
+++ b/framework/src/test/java/org/tron/core/capsule/TransactionCapsuleTest.java
@@ -165,7 +165,7 @@ public class TransactionCapsuleTest extends BaseTest {
   public void checkWeightPaddedSigOsakaRejected() throws Exception {
     dbManager.getDynamicPropertiesStore().saveAllowTvmOsaka(1);
     try {
-      List<ByteString> sigs = Collections.singletonList(ByteString.copyFrom(new byte[66]));
+      List<ByteString> sigs = Collections.singletonList(ByteString.copyFrom(new byte[69]));
       TransactionCapsule.checkWeight(singleKeyPermission(), sigs, DUMMY_HASH, null,
           dbManager.getDynamicPropertiesStore());
     } finally {
@@ -176,7 +176,7 @@ public class TransactionCapsuleTest extends BaseTest {
   @Test
   public void checkWeightPaddedSigPreOsaka() {
     dbManager.getDynamicPropertiesStore().saveAllowTvmOsaka(0);
-    List<ByteString> sigs = Collections.singletonList(ByteString.copyFrom(new byte[66]));
+    List<ByteString> sigs = Collections.singletonList(ByteString.copyFrom(new byte[69]));
     try {
       TransactionCapsule.checkWeight(singleKeyPermission(), sigs, DUMMY_HASH, null,
           dbManager.getDynamicPropertiesStore());

--- a/framework/src/test/java/org/tron/core/capsule/TransactionCapsuleTest.java
+++ b/framework/src/test/java/org/tron/core/capsule/TransactionCapsuleTest.java
@@ -157,7 +157,8 @@ public class TransactionCapsuleTest extends BaseTest {
   @Test(expected = SignatureFormatException.class)
   public void checkWeightShortSigRejected() throws Exception {
     List<ByteString> sigs = Collections.singletonList(ByteString.copyFrom(new byte[64]));
-    TransactionCapsule.checkWeight(singleKeyPermission(), sigs, DUMMY_HASH, null, null);
+    TransactionCapsule.checkWeight(singleKeyPermission(), sigs, DUMMY_HASH, null,
+        dbManager.getDynamicPropertiesStore());
   }
 
   @Test(expected = SignatureFormatException.class)
@@ -186,16 +187,10 @@ public class TransactionCapsuleTest extends BaseTest {
     }
   }
 
-  @Test
-  public void checkWeightPaddedSigNullDs() {
-    List<ByteString> sigs = Collections.singletonList(ByteString.copyFrom(new byte[66]));
-    try {
-      TransactionCapsule.checkWeight(singleKeyPermission(), sigs, DUMMY_HASH, null, null);
-    } catch (SignatureFormatException e) {
-      Assert.fail("Padded sig must not be rejected when DS is null: " + e.getMessage());
-    } catch (Exception e) {
-      // other exceptions after the size check — expected
-    }
+  @Test(expected = NullPointerException.class)
+  public void checkWeightNullDynamicPropertiesStoreRejected() throws Exception {
+    List<ByteString> sigs = Collections.singletonList(ByteString.copyFrom(new byte[65]));
+    TransactionCapsule.checkWeight(singleKeyPermission(), sigs, DUMMY_HASH, null, null);
   }
 
   @Test

--- a/framework/src/test/java/org/tron/core/db/TransactionExpireTest.java
+++ b/framework/src/test/java/org/tron/core/db/TransactionExpireTest.java
@@ -184,4 +184,77 @@ public class TransactionExpireTest extends BaseMethodTest {
     Assert.assertEquals(TransactionApprovedList.Result.response_code.COMPUTE_ADDRESS_ERROR,
         transactionApprovedList.getResult().getCode());
   }
+
+  @Test
+  public void testApprovedListPaddedSigOsakaRejected() {
+    initLocalWitness();
+    byte[] address = Args.getLocalWitnesses().getWitnessAccountAddress();
+    ByteString addressByte = ByteString.copyFrom(address);
+
+    AccountCapsule accountCapsule =
+        new AccountCapsule(Protocol.Account.newBuilder().setAddress(addressByte).build());
+    accountCapsule.setBalance(1000_000_000L);
+    dbManager.getChainBaseManager().getAccountStore()
+        .put(accountCapsule.createDbKey(), accountCapsule);
+
+    TransferContract transferContract = TransferContract.newBuilder()
+        .setAmount(1L)
+        .setOwnerAddress(addressByte)
+        .setToAddress(ByteString.copyFrom(ByteArray.fromHexString(
+            Wallet.getAddressPreFixString() + "A389132D6639FBDA4FBC8B659264E6B7C90DB086")))
+        .build();
+    TransactionCapsule capsule =
+        new TransactionCapsule(transferContract, ContractType.TransferContract);
+    capsule.sign(ByteArray.fromHexString(Args.getLocalWitnesses().getPrivateKey()));
+
+    // Replace the valid 65-byte sig with a 66-byte padded one
+    byte[] sig65 = capsule.getInstance().getSignature(0).toByteArray();
+    byte[] sig66 = Arrays.copyOf(sig65, 66); // extra zero byte appended
+    Transaction tx = capsule.getInstance().toBuilder()
+        .clearSignature().addSignature(ByteString.copyFrom(sig66)).build();
+
+    dbManager.getDynamicPropertiesStore().saveAllowTvmOsaka(1);
+    try {
+      TransactionApprovedList result = wallet.getTransactionApprovedList(tx);
+      Assert.assertEquals("Padded sig must be rejected post-Osaka",
+          TransactionApprovedList.Result.response_code.SIGNATURE_FORMAT_ERROR,
+          result.getResult().getCode());
+      Assert.assertTrue(result.getResult().getMessage().contains("66"));
+    } finally {
+      dbManager.getDynamicPropertiesStore().saveAllowTvmOsaka(0);
+    }
+  }
+
+  @Test
+  public void testApprovedListPaddedSigPreOsaka() {
+    initLocalWitness();
+    byte[] address = Args.getLocalWitnesses().getWitnessAccountAddress();
+    ByteString addressByte = ByteString.copyFrom(address);
+    AccountCapsule accountCapsule =
+        new AccountCapsule(Protocol.Account.newBuilder().setAddress(addressByte).build());
+    accountCapsule.setBalance(1000_000_000L);
+    dbManager.getChainBaseManager().getAccountStore()
+        .put(accountCapsule.createDbKey(), accountCapsule);
+
+    TransferContract transferContract = TransferContract.newBuilder()
+        .setAmount(1L)
+        .setOwnerAddress(addressByte)
+        .setToAddress(ByteString.copyFrom(ByteArray.fromHexString(
+            Wallet.getAddressPreFixString() + "A389132D6639FBDA4FBC8B659264E6B7C90DB086")))
+        .build();
+    TransactionCapsule capsule =
+        new TransactionCapsule(transferContract, ContractType.TransferContract);
+    capsule.sign(ByteArray.fromHexString(Args.getLocalWitnesses().getPrivateKey()));
+
+    byte[] sig65 = capsule.getInstance().getSignature(0).toByteArray();
+    byte[] sig66 = Arrays.copyOf(sig65, 66);
+    Transaction tx = capsule.getInstance().toBuilder()
+        .clearSignature().addSignature(ByteString.copyFrom(sig66)).build();
+
+    dbManager.getDynamicPropertiesStore().saveAllowTvmOsaka(0);
+    TransactionApprovedList result = wallet.getTransactionApprovedList(tx);
+    Assert.assertNotEquals("Padded sig must not be rejected by size check before Osaka",
+        TransactionApprovedList.Result.response_code.SIGNATURE_FORMAT_ERROR,
+        result.getResult().getCode());
+  }
 }

--- a/framework/src/test/java/org/tron/core/db/TransactionExpireTest.java
+++ b/framework/src/test/java/org/tron/core/db/TransactionExpireTest.java
@@ -207,19 +207,19 @@ public class TransactionExpireTest extends BaseMethodTest {
         new TransactionCapsule(transferContract, ContractType.TransferContract);
     capsule.sign(ByteArray.fromHexString(Args.getLocalWitnesses().getPrivateKey()));
 
-    // Replace the valid 65-byte sig with a 66-byte padded one
+    // Replace the valid 65-byte sig with a 69-byte over-padded one (exceeds MAX_SIGNATURE_SIZE=68)
     byte[] sig65 = capsule.getInstance().getSignature(0).toByteArray();
-    byte[] sig66 = Arrays.copyOf(sig65, 66); // extra zero byte appended
+    byte[] sig69 = Arrays.copyOf(sig65, 69);
     Transaction tx = capsule.getInstance().toBuilder()
-        .clearSignature().addSignature(ByteString.copyFrom(sig66)).build();
+        .clearSignature().addSignature(ByteString.copyFrom(sig69)).build();
 
     dbManager.getDynamicPropertiesStore().saveAllowTvmOsaka(1);
     try {
       TransactionApprovedList result = wallet.getTransactionApprovedList(tx);
-      Assert.assertEquals("Padded sig must be rejected post-Osaka",
+      Assert.assertEquals("Over-padded sig must be rejected post-Osaka",
           TransactionApprovedList.Result.response_code.SIGNATURE_FORMAT_ERROR,
           result.getResult().getCode());
-      Assert.assertTrue(result.getResult().getMessage().contains("66"));
+      Assert.assertTrue(result.getResult().getMessage().contains("69"));
     } finally {
       dbManager.getDynamicPropertiesStore().saveAllowTvmOsaka(0);
     }

--- a/framework/src/test/java/org/tron/core/db/TransactionExpireTest.java
+++ b/framework/src/test/java/org/tron/core/db/TransactionExpireTest.java
@@ -186,7 +186,10 @@ public class TransactionExpireTest extends BaseMethodTest {
   }
 
   @Test
-  public void testApprovedListPaddedSigOsakaRejected() {
+  public void testApprovedListPaddedSigPostOsakaAccepted() {
+    // Read-only introspection must not reject a 69-byte sig post-Osaka — the
+    // upper bound is meant to gate new submissions, not block lookups of
+    // historical transactions committed before the size cap existed.
     initLocalWitness();
     byte[] address = Args.getLocalWitnesses().getWitnessAccountAddress();
     ByteString addressByte = ByteString.copyFrom(address);
@@ -207,7 +210,6 @@ public class TransactionExpireTest extends BaseMethodTest {
         new TransactionCapsule(transferContract, ContractType.TransferContract);
     capsule.sign(ByteArray.fromHexString(Args.getLocalWitnesses().getPrivateKey()));
 
-    // Replace the valid 65-byte sig with a 69-byte over-padded one (exceeds MAX_SIGNATURE_SIZE=68)
     byte[] sig65 = capsule.getInstance().getSignature(0).toByteArray();
     byte[] sig69 = Arrays.copyOf(sig65, 69);
     Transaction tx = capsule.getInstance().toBuilder()
@@ -216,13 +218,41 @@ public class TransactionExpireTest extends BaseMethodTest {
     dbManager.getDynamicPropertiesStore().saveAllowTvmOsaka(1);
     try {
       TransactionApprovedList result = wallet.getTransactionApprovedList(tx);
-      Assert.assertEquals("Over-padded sig must be rejected post-Osaka",
+      Assert.assertNotEquals("Padded sig must not be size-rejected on read-only path post-Osaka",
           TransactionApprovedList.Result.response_code.SIGNATURE_FORMAT_ERROR,
           result.getResult().getCode());
-      Assert.assertTrue(result.getResult().getMessage().contains("69"));
     } finally {
       dbManager.getDynamicPropertiesStore().saveAllowTvmOsaka(0);
     }
+  }
+
+  @Test
+  public void testApprovedListShortSigRejected() {
+    // Lower bound is still enforced on the read-only path.
+    initLocalWitness();
+    byte[] address = Args.getLocalWitnesses().getWitnessAccountAddress();
+    ByteString addressByte = ByteString.copyFrom(address);
+    AccountCapsule accountCapsule =
+        new AccountCapsule(Protocol.Account.newBuilder().setAddress(addressByte).build());
+    accountCapsule.setBalance(1000_000_000L);
+    dbManager.getChainBaseManager().getAccountStore()
+        .put(accountCapsule.createDbKey(), accountCapsule);
+
+    TransferContract transferContract = TransferContract.newBuilder()
+        .setAmount(1L)
+        .setOwnerAddress(addressByte)
+        .setToAddress(ByteString.copyFrom(ByteArray.fromHexString(
+            Wallet.getAddressPreFixString() + "A389132D6639FBDA4FBC8B659264E6B7C90DB086")))
+        .build();
+    Transaction tx = new TransactionCapsule(transferContract, ContractType.TransferContract)
+        .getInstance().toBuilder()
+        .addSignature(ByteString.copyFrom(new byte[64]))
+        .build();
+
+    TransactionApprovedList result = wallet.getTransactionApprovedList(tx);
+    Assert.assertEquals("Sig below MIN_SIGNATURE_SIZE must be rejected",
+        TransactionApprovedList.Result.response_code.SIGNATURE_FORMAT_ERROR,
+        result.getResult().getCode());
   }
 
   @Test

--- a/framework/src/test/java/org/tron/core/net/messagehandler/PbftDataSyncHandlerTest.java
+++ b/framework/src/test/java/org/tron/core/net/messagehandler/PbftDataSyncHandlerTest.java
@@ -71,7 +71,7 @@ public class PbftDataSyncHandlerTest {
     DynamicPropertiesStore dynamicPropertiesStore = Mockito.mock(DynamicPropertiesStore.class);
     ChainBaseManager chainBaseManager = Mockito.mock(ChainBaseManager.class);
     Mockito.when(chainBaseManager.getDynamicPropertiesStore()).thenReturn(dynamicPropertiesStore);
-    Mockito.when(dynamicPropertiesStore.isAllowTvmOsaka()).thenReturn(true);
+    Mockito.when(dynamicPropertiesStore.signatureMaxSizeChecked()).thenReturn(true);
 
     Field field = PbftDataSyncHandler.class.getDeclaredField("chainBaseManager");
     field.setAccessible(true);
@@ -102,7 +102,7 @@ public class PbftDataSyncHandlerTest {
     DynamicPropertiesStore dynamicPropertiesStore = Mockito.mock(DynamicPropertiesStore.class);
     ChainBaseManager chainBaseManager = Mockito.mock(ChainBaseManager.class);
     Mockito.when(chainBaseManager.getDynamicPropertiesStore()).thenReturn(dynamicPropertiesStore);
-    Mockito.when(dynamicPropertiesStore.isAllowTvmOsaka()).thenReturn(true);
+    Mockito.when(dynamicPropertiesStore.signatureMaxSizeChecked()).thenReturn(true);
 
     Field field = PbftDataSyncHandler.class.getDeclaredField("chainBaseManager");
     field.setAccessible(true);
@@ -144,7 +144,7 @@ public class PbftDataSyncHandlerTest {
     DynamicPropertiesStore dynamicPropertiesStore = Mockito.mock(DynamicPropertiesStore.class);
     ChainBaseManager chainBaseManager = Mockito.mock(ChainBaseManager.class);
     Mockito.when(chainBaseManager.getDynamicPropertiesStore()).thenReturn(dynamicPropertiesStore);
-    Mockito.when(dynamicPropertiesStore.isAllowTvmOsaka()).thenReturn(true);
+    Mockito.when(dynamicPropertiesStore.signatureMaxSizeChecked()).thenReturn(true);
 
     Field field = PbftDataSyncHandler.class.getDeclaredField("chainBaseManager");
     field.setAccessible(true);

--- a/framework/src/test/java/org/tron/core/net/messagehandler/PbftDataSyncHandlerTest.java
+++ b/framework/src/test/java/org/tron/core/net/messagehandler/PbftDataSyncHandlerTest.java
@@ -85,7 +85,7 @@ public class PbftDataSyncHandlerTest {
         .build();
 
     boolean valid = (boolean) method.invoke(pbftDataSyncHandler, raw,
-        Collections.singletonList(ByteString.copyFrom(new byte[66])),
+        Collections.singletonList(ByteString.copyFrom(new byte[69])),
         Collections.singletonList(ByteString.copyFrom(new byte[21])));
     Assert.assertFalse(valid);
   }

--- a/framework/src/test/java/org/tron/core/net/messagehandler/PbftDataSyncHandlerTest.java
+++ b/framework/src/test/java/org/tron/core/net/messagehandler/PbftDataSyncHandlerTest.java
@@ -5,11 +5,17 @@ import com.google.protobuf.ByteString;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
+import org.bouncycastle.util.encoders.Hex;
 import org.junit.Assert;
 import org.junit.Test;
 import org.mockito.Mockito;
+import org.tron.common.crypto.SignInterface;
+import org.tron.common.crypto.SignUtils;
+import org.tron.common.utils.PublicMethod;
 import org.tron.common.utils.Sha256Hash;
 import org.tron.consensus.base.Param;
 import org.tron.core.ChainBaseManager;
@@ -65,7 +71,7 @@ public class PbftDataSyncHandlerTest {
     DynamicPropertiesStore dynamicPropertiesStore = Mockito.mock(DynamicPropertiesStore.class);
     ChainBaseManager chainBaseManager = Mockito.mock(ChainBaseManager.class);
     Mockito.when(chainBaseManager.getDynamicPropertiesStore()).thenReturn(dynamicPropertiesStore);
-    Mockito.when(dynamicPropertiesStore.getAllowTvmOsaka()).thenReturn(1L);
+    Mockito.when(dynamicPropertiesStore.isAllowTvmOsaka()).thenReturn(true);
 
     Field field = PbftDataSyncHandler.class.getDeclaredField("chainBaseManager");
     field.setAccessible(true);
@@ -88,5 +94,89 @@ public class PbftDataSyncHandlerTest {
         Collections.singletonList(ByteString.copyFrom(new byte[69])),
         Collections.singletonList(ByteString.copyFrom(new byte[21])));
     Assert.assertFalse(valid);
+  }
+
+  @Test
+  public void testValidPbftSignDedupesByAddress() throws Exception {
+    PbftDataSyncHandler pbftDataSyncHandler = new PbftDataSyncHandler();
+    DynamicPropertiesStore dynamicPropertiesStore = Mockito.mock(DynamicPropertiesStore.class);
+    ChainBaseManager chainBaseManager = Mockito.mock(ChainBaseManager.class);
+    Mockito.when(chainBaseManager.getDynamicPropertiesStore()).thenReturn(dynamicPropertiesStore);
+    Mockito.when(dynamicPropertiesStore.isAllowTvmOsaka()).thenReturn(true);
+
+    Field field = PbftDataSyncHandler.class.getDeclaredField("chainBaseManager");
+    field.setAccessible(true);
+    field.set(pbftDataSyncHandler, chainBaseManager);
+
+    Param.getInstance().setAgreeNodeCount(2);
+    Method method = PbftDataSyncHandler.class.getDeclaredMethod("validPbftSign",
+        Protocol.PBFTMessage.Raw.class, java.util.List.class, java.util.List.class);
+    method.setAccessible(true);
+
+    Protocol.PBFTMessage.Raw raw = Protocol.PBFTMessage.Raw.newBuilder()
+        .setViewN(1)
+        .setEpoch(0)
+        .setDataType(Protocol.PBFTMessage.DataType.BLOCK)
+        .setMsgType(Protocol.PBFTMessage.MsgType.COMMIT)
+        .setData(ByteString.copyFromUtf8("block"))
+        .build();
+
+    SignInterface signer = SignUtils.fromPrivate(
+        Hex.decode(PublicMethod.getRandomPrivateKey()), true);
+    byte[] sig65 = signer.Base64toBytes(
+        signer.signHash(Sha256Hash.hash(true, raw.toByteArray())));
+    List<ByteString> paddedSigs = Arrays.asList(
+        ByteString.copyFrom(sig65),
+        ByteString.copyFrom(Arrays.copyOf(sig65, 66)),
+        ByteString.copyFrom(Arrays.copyOf(sig65, 67)),
+        ByteString.copyFrom(Arrays.copyOf(sig65, 68)));
+    List<ByteString> currentSrList = Collections.singletonList(
+        ByteString.copyFrom(signer.getAddress()));
+
+    boolean valid = (boolean) method.invoke(pbftDataSyncHandler, raw,
+        paddedSigs, currentSrList);
+    Assert.assertFalse("trailing-byte padded duplicates must not inflate quorum", valid);
+  }
+
+  @Test
+  public void testValidPbftSignAcceptsQuorumDespiteOneBadSig() throws Exception {
+    PbftDataSyncHandler pbftDataSyncHandler = new PbftDataSyncHandler();
+    DynamicPropertiesStore dynamicPropertiesStore = Mockito.mock(DynamicPropertiesStore.class);
+    ChainBaseManager chainBaseManager = Mockito.mock(ChainBaseManager.class);
+    Mockito.when(chainBaseManager.getDynamicPropertiesStore()).thenReturn(dynamicPropertiesStore);
+    Mockito.when(dynamicPropertiesStore.isAllowTvmOsaka()).thenReturn(true);
+
+    Field field = PbftDataSyncHandler.class.getDeclaredField("chainBaseManager");
+    field.setAccessible(true);
+    field.set(pbftDataSyncHandler, chainBaseManager);
+
+    Param.getInstance().setAgreeNodeCount(3);
+    Method method = PbftDataSyncHandler.class.getDeclaredMethod("validPbftSign",
+        Protocol.PBFTMessage.Raw.class, java.util.List.class, java.util.List.class);
+    method.setAccessible(true);
+
+    Protocol.PBFTMessage.Raw raw = Protocol.PBFTMessage.Raw.newBuilder()
+        .setViewN(1)
+        .setEpoch(0)
+        .setDataType(Protocol.PBFTMessage.DataType.BLOCK)
+        .setMsgType(Protocol.PBFTMessage.MsgType.COMMIT)
+        .setData(ByteString.copyFromUtf8("block"))
+        .build();
+    byte[] dataHash = Sha256Hash.hash(true, raw.toByteArray());
+
+    List<ByteString> srSignList = new ArrayList<>();
+    List<ByteString> currentSrList = new ArrayList<>();
+    for (int i = 0; i < 3; i++) {
+      SignInterface signer = SignUtils.fromPrivate(
+          Hex.decode(PublicMethod.getRandomPrivateKey()), true);
+      srSignList.add(ByteString.copyFrom(signer.Base64toBytes(signer.signHash(dataHash))));
+      currentSrList.add(ByteString.copyFrom(signer.getAddress()));
+    }
+    // An attacker-injected too-short signature must not bring down the whole message.
+    srSignList.add(ByteString.copyFrom(new byte[64]));
+
+    boolean valid = (boolean) method.invoke(pbftDataSyncHandler, raw,
+        srSignList, currentSrList);
+    Assert.assertTrue("quorum of valid sigs must still pass when one sig is malformed", valid);
   }
 }

--- a/framework/src/test/java/org/tron/core/net/messagehandler/PbftDataSyncHandlerTest.java
+++ b/framework/src/test/java/org/tron/core/net/messagehandler/PbftDataSyncHandlerTest.java
@@ -3,12 +3,15 @@ package org.tron.core.net.messagehandler;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.protobuf.ByteString;
 import java.lang.reflect.Field;
+import java.lang.reflect.Method;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Map;
 import org.junit.Assert;
 import org.junit.Test;
 import org.mockito.Mockito;
 import org.tron.common.utils.Sha256Hash;
+import org.tron.consensus.base.Param;
 import org.tron.core.ChainBaseManager;
 import org.tron.core.capsule.BlockCapsule;
 import org.tron.core.capsule.PbftSignCapsule;
@@ -54,5 +57,36 @@ public class PbftDataSyncHandlerTest {
     field1.setAccessible(true);
     Map map = new ObjectMapper().convertValue(field1.get(pbftDataSyncHandler), Map.class);
     Assert.assertFalse(map.containsKey(0));
+  }
+
+  @Test
+  public void testValidPbftSignPaddedSigOsakaRejected() throws Exception {
+    PbftDataSyncHandler pbftDataSyncHandler = new PbftDataSyncHandler();
+    DynamicPropertiesStore dynamicPropertiesStore = Mockito.mock(DynamicPropertiesStore.class);
+    ChainBaseManager chainBaseManager = Mockito.mock(ChainBaseManager.class);
+    Mockito.when(chainBaseManager.getDynamicPropertiesStore()).thenReturn(dynamicPropertiesStore);
+    Mockito.when(dynamicPropertiesStore.getAllowTvmOsaka()).thenReturn(1L);
+
+    Field field = PbftDataSyncHandler.class.getDeclaredField("chainBaseManager");
+    field.setAccessible(true);
+    field.set(pbftDataSyncHandler, chainBaseManager);
+
+    Param.getInstance().setAgreeNodeCount(1);
+    Method method = PbftDataSyncHandler.class.getDeclaredMethod("validPbftSign",
+        Protocol.PBFTMessage.Raw.class, java.util.List.class, java.util.List.class);
+    method.setAccessible(true);
+
+    Protocol.PBFTMessage.Raw raw = Protocol.PBFTMessage.Raw.newBuilder()
+        .setViewN(1)
+        .setEpoch(0)
+        .setDataType(Protocol.PBFTMessage.DataType.BLOCK)
+        .setMsgType(Protocol.PBFTMessage.MsgType.COMMIT)
+        .setData(ByteString.copyFromUtf8("block"))
+        .build();
+
+    boolean valid = (boolean) method.invoke(pbftDataSyncHandler, raw,
+        Collections.singletonList(ByteString.copyFrom(new byte[66])),
+        Collections.singletonList(ByteString.copyFrom(new byte[21])));
+    Assert.assertFalse(valid);
   }
 }

--- a/framework/src/test/java/org/tron/core/net/messagehandler/PbftMsgHandlerTest.java
+++ b/framework/src/test/java/org/tron/core/net/messagehandler/PbftMsgHandlerTest.java
@@ -5,6 +5,8 @@ import static org.mockito.Mockito.mock;
 import com.google.protobuf.ByteString;
 import java.io.File;
 import java.net.InetSocketAddress;
+import java.security.SignatureException;
+import java.util.Arrays;
 import org.bouncycastle.util.encoders.Hex;
 import org.junit.After;
 import org.junit.AfterClass;
@@ -119,5 +121,53 @@ public class PbftMsgHandlerTest {
     }
 
     Assert.assertEquals(1, PeerManager.getPeers().size());
+  }
+
+  @Test
+  public void testPbftPaddedSigOsakaRejected() throws Exception {
+    InetSocketAddress a1 = new InetSocketAddress("127.0.0.1", 10001);
+    Channel c1 = mock(Channel.class);
+    Mockito.when(c1.getInetSocketAddress()).thenReturn(a1);
+    Mockito.when(c1.getInetAddress()).thenReturn(a1.getAddress());
+    PeerManager.add(context, c1);
+
+    peer = PeerManager.getPeers().get(0);
+    BlockCapsule blockCapsule = new BlockCapsule(1, Sha256Hash.ZERO_HASH,
+        System.currentTimeMillis(), ByteString.EMPTY);
+    Protocol.PBFTMessage.Raw raw = Protocol.PBFTMessage.Raw.newBuilder()
+        .setViewN(blockCapsule.getNum())
+        .setEpoch(0)
+        .setDataType(Protocol.PBFTMessage.DataType.BLOCK)
+        .setMsgType(Protocol.PBFTMessage.MsgType.PREPREPARE)
+        .setData(blockCapsule.getBlockId().getByteString())
+        .build();
+    SignInterface sign = SignUtils.fromPrivate(Hex.decode(PublicMethod.getRandomPrivateKey()),
+        true);
+    byte[] sig = sign.Base64toBytes(sign.signHash(Sha256Hash.hash(true, raw.toByteArray())));
+    byte[] paddedSig = Arrays.copyOf(sig, 66);
+    Protocol.PBFTMessage message = Protocol.PBFTMessage.newBuilder()
+        .setRawData(raw)
+        .setSignature(ByteString.copyFrom(paddedSig))
+        .build();
+
+    PbftMessage pbftMessage = new PbftMessage();
+    pbftMessage.setType(MessageTypes.PBFT_MSG.asByte());
+    pbftMessage.setPbftMessage(message);
+    pbftMessage.setData(message.toByteArray());
+    pbftMessage.setSwitch(blockCapsule.isSwitch());
+    Param.getInstance().setPbftInterface(context.getBean(PbftBaseImpl.class));
+    peer.setNeedSyncFromPeer(false);
+
+    DynamicPropertiesStore dynamicPropertiesStore = context.getBean(DynamicPropertiesStore.class);
+    dynamicPropertiesStore.saveAllowPBFT(1);
+    dynamicPropertiesStore.saveAllowTvmOsaka(1);
+    try {
+      context.getBean(PbftMsgHandler.class).processMessage(peer, pbftMessage);
+      Assert.fail("Padded PBFT signature must be rejected post-Osaka");
+    } catch (SignatureException e) {
+      Assert.assertTrue(e.getMessage().contains("PBFT signature size is 66"));
+    } finally {
+      dynamicPropertiesStore.saveAllowTvmOsaka(0);
+    }
   }
 }

--- a/framework/src/test/java/org/tron/core/net/messagehandler/PbftMsgHandlerTest.java
+++ b/framework/src/test/java/org/tron/core/net/messagehandler/PbftMsgHandlerTest.java
@@ -162,10 +162,11 @@ public class PbftMsgHandlerTest {
     dynamicPropertiesStore.saveAllowPBFT(1);
     dynamicPropertiesStore.saveAllowTvmOsaka(1);
     try {
-      context.getBean(PbftMsgHandler.class).processMessage(peer, pbftMessage);
-      Assert.fail("Padded PBFT signature must be rejected post-Osaka");
-    } catch (SignatureException e) {
-      Assert.assertTrue(e.getMessage().contains("PBFT signature size is 69"));
+      SignatureException e = Assert.assertThrows(
+          SignatureException.class,
+          () -> context.getBean(PbftMsgHandler.class).processMessage(peer, pbftMessage));
+      Assert.assertTrue("Padded PBFT signature must be rejected post-Osaka",
+          e.getMessage().contains("PBFT signature size is 69"));
     } finally {
       dynamicPropertiesStore.saveAllowTvmOsaka(0);
     }

--- a/framework/src/test/java/org/tron/core/net/messagehandler/PbftMsgHandlerTest.java
+++ b/framework/src/test/java/org/tron/core/net/messagehandler/PbftMsgHandlerTest.java
@@ -144,7 +144,7 @@ public class PbftMsgHandlerTest {
     SignInterface sign = SignUtils.fromPrivate(Hex.decode(PublicMethod.getRandomPrivateKey()),
         true);
     byte[] sig = sign.Base64toBytes(sign.signHash(Sha256Hash.hash(true, raw.toByteArray())));
-    byte[] paddedSig = Arrays.copyOf(sig, 66);
+    byte[] paddedSig = Arrays.copyOf(sig, 69);
     Protocol.PBFTMessage message = Protocol.PBFTMessage.newBuilder()
         .setRawData(raw)
         .setSignature(ByteString.copyFrom(paddedSig))
@@ -165,7 +165,7 @@ public class PbftMsgHandlerTest {
       context.getBean(PbftMsgHandler.class).processMessage(peer, pbftMessage);
       Assert.fail("Padded PBFT signature must be rejected post-Osaka");
     } catch (SignatureException e) {
-      Assert.assertTrue(e.getMessage().contains("PBFT signature size is 66"));
+      Assert.assertTrue(e.getMessage().contains("PBFT signature size is 69"));
     } finally {
       dynamicPropertiesStore.saveAllowTvmOsaka(0);
     }

--- a/framework/src/test/java/org/tron/core/net/services/RelayServiceTest.java
+++ b/framework/src/test/java/org/tron/core/net/services/RelayServiceTest.java
@@ -10,6 +10,7 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.net.InetSocketAddress;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Set;
@@ -223,6 +224,66 @@ public class RelayServiceTest extends BaseTest {
     } catch (Exception e) {
       logger.info("", e);
       assert false;
+    }
+  }
+
+  @Test
+  public void testCheckHelloMessagePaddedSigOsakaRejected() {
+    initWitness();
+    String key = "0154435f065a57fec6af1e12eaa2fa600030639448d7809f4c65bdcf8baed7e5";
+    ByteString address = getFromHexString("418A8D690BF36806C36A7DAE3AF796643C1AA9CC01");
+    InetSocketAddress a1 = new InetSocketAddress("127.0.0.1", 10001);
+    Node node = new Node(NetUtil.getNodeId(), a1.getAddress().getHostAddress(),
+        null, a1.getPort());
+
+    SignInterface cryptoEngine = SignUtils.fromPrivate(ByteArray.fromHexString(key),
+        Args.getInstance().isECKeyCryptoEngine());
+    HelloMessage helloMessage = new HelloMessage(node, System.currentTimeMillis(),
+        ChainBaseManager.getChainBaseManager());
+    byte[] sig = cryptoEngine.Base64toBytes(cryptoEngine.signHash(Sha256Hash.of(CommonParameter
+        .getInstance().isECKeyCryptoEngine(), ByteArray.fromLong(helloMessage
+        .getTimestamp())).getBytes()));
+    byte[] paddedSig = Arrays.copyOf(sig, 66);
+    helloMessage.setHelloMessage(helloMessage.getHelloMessage().toBuilder()
+        .setAddress(address)
+        .setSignature(ByteString.copyFrom(paddedSig))
+        .build());
+
+    Channel c1 = mock(Channel.class);
+    Mockito.when(c1.getInetSocketAddress()).thenReturn(a1);
+    Mockito.when(c1.getInetAddress()).thenReturn(a1.getAddress());
+    Channel c2 = mock(Channel.class);
+    Mockito.when(c2.getInetSocketAddress()).thenReturn(a1);
+    Mockito.when(c2.getInetAddress()).thenReturn(a1.getAddress());
+
+    Args.getInstance().fastForward = true;
+    ApplicationContext ctx = (ApplicationContext) ReflectUtils.getFieldObject(p2pEventHandler,
+        "ctx");
+    PeerConnection peer1 = PeerManager.add(ctx, c1);
+    assert peer1 != null;
+    peer1.setAddress(address);
+    PeerConnection peer2 = PeerManager.add(ctx, c2);
+    assert peer2 != null;
+    peer2.setAddress(address);
+
+    ReflectUtils.setFieldValue(tronNetService, "p2pConfig", new P2pConfig());
+
+    try {
+      Field field = service.getClass().getDeclaredField("witnessScheduleStore");
+      field.setAccessible(true);
+      field.set(service, chainBaseManager.getWitnessScheduleStore());
+
+      Field field2 = service.getClass().getDeclaredField("manager");
+      field2.setAccessible(true);
+      field2.set(service, dbManager);
+
+      chainBaseManager.getDynamicPropertiesStore().saveAllowTvmOsaka(1);
+      Assert.assertFalse(service.checkHelloMessage(helloMessage, c1));
+    } catch (Exception e) {
+      logger.info("", e);
+      assert false;
+    } finally {
+      chainBaseManager.getDynamicPropertiesStore().saveAllowTvmOsaka(0);
     }
   }
 

--- a/framework/src/test/java/org/tron/core/net/services/RelayServiceTest.java
+++ b/framework/src/test/java/org/tron/core/net/services/RelayServiceTest.java
@@ -243,7 +243,7 @@ public class RelayServiceTest extends BaseTest {
     byte[] sig = cryptoEngine.Base64toBytes(cryptoEngine.signHash(Sha256Hash.of(CommonParameter
         .getInstance().isECKeyCryptoEngine(), ByteArray.fromLong(helloMessage
         .getTimestamp())).getBytes()));
-    byte[] paddedSig = Arrays.copyOf(sig, 66);
+    byte[] paddedSig = Arrays.copyOf(sig, 69);
     helloMessage.setHelloMessage(helloMessage.getHelloMessage().toBuilder()
         .setAddress(address)
         .setSignature(ByteString.copyFrom(paddedSig))

--- a/framework/src/test/java/org/tron/core/zksnark/ShieldedReceiveTest.java
+++ b/framework/src/test/java/org/tron/core/zksnark/ShieldedReceiveTest.java
@@ -333,7 +333,8 @@ public class ShieldedReceiveTest extends BaseTest {
 
     //Add public address sign
     transactionCap = TransactionUtils.addTransactionSign(transactionCap.getInstance(),
-            ADDRESS_ONE_PRIVATE_KEY, chainBaseManager.getAccountStore());
+            ADDRESS_ONE_PRIVATE_KEY, chainBaseManager.getAccountStore(),
+        chainBaseManager.getDynamicPropertiesStore());
     try {
       dbManager.pushTransaction(transactionCap);
     } catch (Exception e) {


### PR DESCRIPTION
## Summary

- Tighten signature length validation across transaction, block and PBFT processing
- Gate the new validation on the TVM Osaka proposal parameter to preserve compatibility with historical data
- Centralize the bounds in `ChainConstant.MIN_SIGNATURE_SIZE` (65) and `MAX_SIGNATURE_SIZE` (68), and the check itself in `SignUtils.isValidLength(int size, boolean osakaAllowed)`; a signature is rejected if `size < MIN_SIGNATURE_SIZE` or, post-Osaka, `size > MAX_SIGNATURE_SIZE`
- Apply the predicate consistently at every signature-size callsite (`TransactionCapsule.checkWeight`, `BlockCapsule.validateSignature`, `Wallet.getTransactionApprovedList`, `RelayService.checkHelloMessage`, `PbftBaseMessage.analyzeSignature`, `PbftDataSyncHandler.ValidPbftSignTask`)
- Harden PBFT quorum accounting so it remains robust under non-canonical signature encodings

## Design notes

### Size bound: 65..68 instead of strict 65

The post-Osaka window accepts `65..68` bytes rather than enforcing a strict `== 65`. This is a deliberate compatibility compromise:

- A canonical ECDSA signature is exactly 65 bytes (`r || s || v`).
- Historical on-chain data contains signatures with a small amount of trailing padding that ECDSA recovery silently ignores.
- Choosing `MAX_SIGNATURE_SIZE = 68` bounds the previously unbounded encoding window while remaining compatible with the historical data on chain.
- Long-term goal is to converge to a strict `== 65` check once the historical compatibility window is no longer needed. The bound is centralized in `ChainConstant` and the check in `SignUtils.isValidLength`, so tightening becomes a one-line change.

### Predicate placement

The size check lives in `SignUtils.isValidLength(int size, boolean osakaAllowed)` (crypto module), not in `ChainConstant`:

- The check is a signature concern, not a chain constant.
- The `crypto` module is reachable from every callsite (`chainbase`, `consensus`, `framework`).
- A single predicate eliminates duplicated bounds checks across six sites and makes the bound trivially tightenable.

A companion helper `DynamicPropertiesStore.isAllowTvmOsaka()` replaces the previous inline `getAllowTvmOsaka() == 1L` so callers thread a boolean, not a long.

### PBFT quorum accounting

`validPbftSign` now dedupes accepted votes by the recovered SR address rather than by raw signature bytes. This keeps quorum accounting robust regardless of the exact byte-level encoding of each submitted signature. A regression test (`PbftDataSyncHandlerTest.testValidPbftSignDedupesByAddress`) covers the path.

## Breaking changes

`chainbase` module public-method signatures changed to thread `DynamicPropertiesStore` through the size check:

| Method | Before | After |
|---|---|---|
| `TransactionCapsule.checkWeight` | `(Permission, List<ByteString>, byte[], List<ByteString>)` | `(..., DynamicPropertiesStore)` (extra trailing arg) |
| `TransactionCapsule.addSign` | `(byte[], AccountStore)` | `(byte[], AccountStore, DynamicPropertiesStore)` |

`checkWeight` additionally calls `Objects.requireNonNull(dynamicPropertiesStore)`. All in-tree callers are updated. External JVM consumers of the `chainbase` artifact (SDKs, signing services, third-party tools) must add the new argument; existing call sites will fail to compile rather than silently misbehave.

## Changed files

| File | Change |
|------|--------|
| `common/.../config/Parameter.java` | Add `MIN_SIGNATURE_SIZE` / `MAX_SIGNATURE_SIZE` to `ChainConstant` |
| `crypto/.../SignUtils.java` | Add `isValidLength(int, boolean)` predicate |
| `chainbase/.../DynamicPropertiesStore.java` | Add `isAllowTvmOsaka()` helper |
| `chainbase/.../TransactionCapsule.java` | Thread `DynamicPropertiesStore` through `checkWeight` / `addSign`; enforce size bounds post-Osaka |
| `chainbase/.../BlockCapsule.java` | Apply size bounds to witness signatures in `validateSignature` |
| `framework/.../Wallet.java` | Apply size bounds in `getTransactionApprovedList` |
| `framework/.../RelayService.java` | Apply size bounds in `checkHelloMessage` |
| `framework/.../PbftDataSyncHandler.java` | Apply size bounds in `ValidPbftSignTask`; dedupe PBFT quorum by recovered SR address |
| `framework/.../PbftMsgHandler.java` | Pass `DynamicPropertiesStore` into `analyzeSignature` |
| `consensus/.../PbftBaseMessage.java` | Apply size bounds in `analyzeSignature` |
| `consensus/.../PbftMessageHandle.java` | Pass `DynamicPropertiesStore` into `analyzeSignature` |
| `actuator/.../TransactionUtil.java` | Update `checkWeight` call site |

## Test plan

- [ ] `TransactionCapsuleTest` — `checkWeight` size enforcement pre/post-Osaka
- [ ] `BlockCapsuleTest` — witness signature size enforcement pre/post-Osaka
- [ ] `TransactionExpireTest` — `getTransactionApprovedList` size enforcement pre/post-Osaka
- [ ] `TransactionUtilTest` — `getTransactionSignWeight` size enforcement post-Osaka
- [ ] `PbftDataSyncHandlerTest` — PBFT sign size enforcement post-Osaka; quorum dedup (`testValidPbftSignDedupesByAddress`)
- [ ] `PbftMsgHandlerTest` — PBFT message sign size enforcement post-Osaka
- [ ] `RelayServiceTest` — hello message sign size enforcement post-Osaka
