### PR TITLE
fix(net): enforce 65-byte signature length

### DIFF
--- a/framework/src/main/java/org/tron/core/Wallet.java
+++ b/framework/src/main/java/org/tron/core/Wallet.java
@@ -24,6 +24,7 @@ import static org.tron.common.math.Maths.max;
 import static org.tron.common.utils.Commons.getAssetIssueStoreFinal;
 import static org.tron.common.utils.Commons.getExchangeStoreFinal;
 import static org.tron.common.utils.WalletUtil.isConstant;
+import static org.tron.core.Constant.PER_SIGN_LENGTH;
 import static org.tron.core.capsule.utils.TransactionUtil.buildInternalTransaction;
 import static org.tron.core.config.Parameter.ChainConstant.BLOCK_PRODUCED_INTERVAL;
 import static org.tron.core.config.Parameter.ChainConstant.TRX_PRECISION;
@@ -505,6 +506,16 @@ public class Wallet {
     trx.setTime(System.currentTimeMillis());
     Sha256Hash txID = trx.getTransactionId();
     try {
+      for (ByteString sig : signedTransaction.getSignatureList()) {
+        if (sig.size() != PER_SIGN_LENGTH) {
+          String info = "Signature size is " + sig.size();
+          logger.warn("Broadcast transaction {} has failed, {}.", txID, info);
+          return builder.setResult(false).setCode(response_code.SIGERROR)
+              .setMessage(ByteString.copyFromUtf8("Validate signature error: " + info))
+              .build();
+        }
+      }
+
       if (tronNetDelegate.isBlockUnsolidified()) {
         logger.warn("Broadcast transaction {} has failed, block unsolidified.", txID);
         return builder.setResult(false).setCode(response_code.BLOCK_UNSOLIDIFIED)

--- a/framework/src/main/java/org/tron/core/net/messagehandler/TransactionsMsgHandler.java
+++ b/framework/src/main/java/org/tron/core/net/messagehandler/TransactionsMsgHandler.java
@@ -1,5 +1,8 @@
 package org.tron.core.net.messagehandler;
 
+import static org.tron.core.Constant.PER_SIGN_LENGTH;
+
+import com.google.protobuf.ByteString;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -141,6 +144,12 @@ public class TransactionsMsgHandler implements TronMsgHandler {
       if (trx.getRawData().getContractCount() < 1) {
         throw new P2pException(TypeEnum.BAD_TRX,
             "tx " + item.getHash() + " contract size should be greater than 0");
+      }
+      for (ByteString sig : trx.getSignatureList()) {
+        if (sig.size() != PER_SIGN_LENGTH) {
+          throw new P2pException(TypeEnum.BAD_TRX,
+              "tx " + item.getHash() + " signature size is " + sig.size());
+        }
       }
     }
   }

--- a/framework/src/main/java/org/tron/core/net/service/relay/RelayService.java
+++ b/framework/src/main/java/org/tron/core/net/service/relay/RelayService.java
@@ -1,5 +1,7 @@
 package org.tron.core.net.service.relay;
 
+import static org.tron.core.Constant.PER_SIGN_LENGTH;
+
 import com.google.protobuf.ByteString;
 import java.net.InetSocketAddress;
 import java.util.Arrays;
@@ -147,6 +149,12 @@ public class RelayService {
           channel.getInetAddress(),
           ByteArray.toHexString(msg.getAddress().toByteArray()),
           MAX_PEER_COUNT_PER_ADDRESS);
+      return false;
+    }
+
+    if (msg.getSignature().size() != PER_SIGN_LENGTH) {
+      logger.warn("HelloMessage from {}, signature size is {}.",
+          channel.getInetAddress(), msg.getSignature().size());
       return false;
     }
 

--- a/framework/src/test/java/org/tron/core/WalletMockTest.java
+++ b/framework/src/test/java/org/tron/core/WalletMockTest.java
@@ -165,6 +165,47 @@ public class WalletMockTest {
 
 
   @Test
+  public void testBroadcastTxInvalidSigLength() throws Exception {
+    Wallet wallet = new Wallet();
+    TronNetDelegate tronNetDelegateMock = mock(TronNetDelegate.class);
+    Field field = wallet.getClass().getDeclaredField("tronNetDelegate");
+    field.setAccessible(true);
+    field.set(wallet, tronNetDelegateMock);
+
+    // signature shorter than 65 bytes → SIGERROR
+    Protocol.Transaction shortSig = Protocol.Transaction.newBuilder()
+        .addSignature(ByteString.copyFrom(new byte[64]))
+        .build();
+    GrpcAPI.Return ret = wallet.broadcastTransaction(shortSig);
+    assertEquals(GrpcAPI.Return.response_code.SIGERROR, ret.getCode());
+
+    // signature longer than 65 bytes → SIGERROR
+    Protocol.Transaction longSig = Protocol.Transaction.newBuilder()
+        .addSignature(ByteString.copyFrom(new byte[66]))
+        .build();
+    ret = wallet.broadcastTransaction(longSig);
+    assertEquals(GrpcAPI.Return.response_code.SIGERROR, ret.getCode());
+
+    // empty signature → SIGERROR
+    Protocol.Transaction emptySig = Protocol.Transaction.newBuilder()
+        .addSignature(ByteString.EMPTY)
+        .build();
+    ret = wallet.broadcastTransaction(emptySig);
+    assertEquals(GrpcAPI.Return.response_code.SIGERROR, ret.getCode());
+
+    // tronNetDelegate must not be consulted because the request is rejected up front
+    Mockito.verify(tronNetDelegateMock, Mockito.never()).isBlockUnsolidified();
+
+    // 65-byte signature passes the length check and proceeds to downstream logic
+    when(tronNetDelegateMock.isBlockUnsolidified()).thenReturn(true);
+    Protocol.Transaction validSig = Protocol.Transaction.newBuilder()
+        .addSignature(ByteString.copyFrom(new byte[65]))
+        .build();
+    ret = wallet.broadcastTransaction(validSig);
+    assertEquals(GrpcAPI.Return.response_code.BLOCK_UNSOLIDIFIED, ret.getCode());
+  }
+
+  @Test
   public void testBroadcastTransactionBlockUnsolidified() throws Exception {
     Wallet wallet = new Wallet();
     Protocol.Transaction transaction = Protocol.Transaction.newBuilder().build();

--- a/framework/src/test/java/org/tron/core/net/messagehandler/TransactionsMsgHandlerTest.java
+++ b/framework/src/test/java/org/tron/core/net/messagehandler/TransactionsMsgHandlerTest.java
@@ -338,6 +338,75 @@ public class TransactionsMsgHandlerTest extends BaseTest {
   }
 
   @Test
+  public void testInvalidSigLength() throws Exception {
+    TransactionsMsgHandler handler = new TransactionsMsgHandler();
+    handler.init();
+    try {
+      PeerConnection peer = Mockito.mock(PeerConnection.class);
+
+      BalanceContract.TransferContract transferContract = BalanceContract.TransferContract
+          .newBuilder()
+          .setAmount(10)
+          .setOwnerAddress(ByteString.copyFrom(ByteArray.fromHexString("121212a9cf")))
+          .setToAddress(ByteString.copyFrom(ByteArray.fromHexString("232323a9cf")))
+          .build();
+
+      // signature shorter than 65 bytes → BAD_TRX
+      Protocol.Transaction shortSigTrx = Protocol.Transaction.newBuilder()
+          .setRawData(Protocol.Transaction.raw.newBuilder()
+              .addContract(Protocol.Transaction.Contract.newBuilder()
+                  .setType(Protocol.Transaction.Contract.ContractType.TransferContract)
+                  .setParameter(Any.pack(transferContract)).build())
+              .build())
+          .addSignature(ByteString.copyFrom(new byte[64]))
+          .build();
+
+      List<Protocol.Transaction> shortList = new ArrayList<>();
+      shortList.add(shortSigTrx);
+      stubAdvInvRequest(peer, new TransactionsMessage(shortList));
+      P2pException shortEx = Assert.assertThrows(P2pException.class,
+          () -> handler.processMessage(peer, new TransactionsMessage(shortList)));
+      Assert.assertEquals(TypeEnum.BAD_TRX, shortEx.getType());
+
+      // signature longer than 65 bytes → BAD_TRX
+      Protocol.Transaction longSigTrx = Protocol.Transaction.newBuilder()
+          .setRawData(Protocol.Transaction.raw.newBuilder()
+              .setRefBlockNum(1)
+              .addContract(Protocol.Transaction.Contract.newBuilder()
+                  .setType(Protocol.Transaction.Contract.ContractType.TransferContract)
+                  .setParameter(Any.pack(transferContract)).build())
+              .build())
+          .addSignature(ByteString.copyFrom(new byte[66]))
+          .build();
+
+      List<Protocol.Transaction> longList = new ArrayList<>();
+      longList.add(longSigTrx);
+      stubAdvInvRequest(peer, new TransactionsMessage(longList));
+      P2pException longEx = Assert.assertThrows(P2pException.class,
+          () -> handler.processMessage(peer, new TransactionsMessage(longList)));
+      Assert.assertEquals(TypeEnum.BAD_TRX, longEx.getType());
+
+      // exactly 65 bytes → passes the length check (no P2pException from check)
+      Protocol.Transaction validSigTrx = Protocol.Transaction.newBuilder()
+          .setRawData(Protocol.Transaction.raw.newBuilder()
+              .setRefBlockNum(2)
+              .addContract(Protocol.Transaction.Contract.newBuilder()
+                  .setType(Protocol.Transaction.Contract.ContractType.TransferContract)
+                  .setParameter(Any.pack(transferContract)).build())
+              .build())
+          .addSignature(ByteString.copyFrom(new byte[65]))
+          .build();
+
+      List<Protocol.Transaction> validList = new ArrayList<>();
+      validList.add(validSigTrx);
+      stubAdvInvRequest(peer, new TransactionsMessage(validList));
+      handler.processMessage(peer, new TransactionsMessage(validList));
+    } finally {
+      handler.close();
+    }
+  }
+
+  @Test
   public void testIsBusyWithCachedTransactions() throws Exception {
     TransactionsMsgHandler handler = new TransactionsMsgHandler();
 

--- a/framework/src/test/java/org/tron/core/net/services/RelayServiceTest.java
+++ b/framework/src/test/java/org/tron/core/net/services/RelayServiceTest.java
@@ -220,6 +220,30 @@ public class RelayServiceTest extends BaseTest {
 
       boolean res = service.checkHelloMessage(helloMessage, c1);
       Assert.assertTrue(res);
+
+      HelloMessage shortSigMsg = new HelloMessage(node, System.currentTimeMillis(),
+          ChainBaseManager.getChainBaseManager());
+      shortSigMsg.setHelloMessage(shortSigMsg.getHelloMessage().toBuilder()
+          .setAddress(address)
+          .setSignature(ByteString.copyFrom(new byte[64]))
+          .build());
+      Assert.assertFalse(service.checkHelloMessage(shortSigMsg, c1));
+
+      HelloMessage longSigMsg = new HelloMessage(node, System.currentTimeMillis(),
+          ChainBaseManager.getChainBaseManager());
+      longSigMsg.setHelloMessage(longSigMsg.getHelloMessage().toBuilder()
+          .setAddress(address)
+          .setSignature(ByteString.copyFrom(new byte[66]))
+          .build());
+      Assert.assertFalse(service.checkHelloMessage(longSigMsg, c1));
+
+      HelloMessage emptySigMsg = new HelloMessage(node, System.currentTimeMillis(),
+          ChainBaseManager.getChainBaseManager());
+      emptySigMsg.setHelloMessage(emptySigMsg.getHelloMessage().toBuilder()
+          .setAddress(address)
+          .setSignature(ByteString.EMPTY)
+          .build());
+      Assert.assertFalse(service.checkHelloMessage(emptySigMsg, c1));
     } catch (Exception e) {
       logger.info("", e);
       assert false;


### PR DESCRIPTION
**What does this PR do?**

Adds a strict 65-byte length check on signatures received at broadcast / P2P admission entrypoints, before any signature recovery work is done:

- `Wallet.broadcastTransaction` rejects the transaction with `SIGERROR` when any signature in the list is not 65 bytes.
- `TransactionsMsgHandler.check` throws `P2pException(BAD_TRX)` when any signature in a `TransactionsMessage` is not 65 bytes, causing the peer to be disconnected with `BAD_TX`.
- `RelayService.checkHelloMessage` returns `false` when the `HelloMessage` signature from a fast-forward peer is not 65 bytes.

The constant `Constant.PER_SIGN_LENGTH` (= 65) is reused everywhere.

**Why are these changes required?**

A TRON transaction / hello signature is encoded as 65 bytes (`r` 32 + `s` 32 + `v` 1). The affected entrypoints currently pass malformed admission payloads into `SignUtils.signatureToAddress` / signature recovery first, which wastes CPU before the request is rejected or fails later.

This PR adds a cheap length check at the network and broadcast boundaries so invalid admission payloads fail before crypto recovery is attempted. This is intentionally scoped to admission handling only.

**Consensus compatibility**

This PR does not change transaction validation for blocks or any shared consensus validation path.

In particular, `TransactionCapsule.checkWeight` currently rejects signatures shorter than 65 bytes, while longer signatures are parsed by the existing `Rsv.fromSignature` behavior using the first 65 bytes. Tightening that shared validation path would be a consensus-impacting behavior change and is intentionally not part of this PR.

The observable behavior change is limited to local broadcast / P2P admission:

- Clients broadcasting transactions with non-65-byte signatures now receive `SIGERROR` before downstream checks.
- Peers sending transaction messages with non-65-byte signatures are rejected at message admission with `BAD_TX`.
- Fast-forward hello messages with non-65-byte signatures are rejected before signature recovery.

**This PR has been tested by:**

- Unit Tests
  - `WalletMockTest#testBroadcastTxInvalidSigLength`: 64 / 66 / empty signatures return `SIGERROR`; 65-byte signature falls through.
  - `TransactionsMsgHandlerTest#testInvalidSigLength`: 64 / 66 / empty signatures raise `P2pException(BAD_TRX)` via `assertThrows`; 65-byte signature passes the new length check.
  - `RelayServiceTest#testCheckHelloMessage`: extended to assert that 64 / 66 / empty `HelloMessage` signatures return `false`; the existing 65-byte case still returns `true`.
- Manual Testing
  - `./gradlew :framework:checkstyleMain :framework:checkstyleTest`
  - `./gradlew :framework:test --tests "org.tron.core.WalletMockTest.testBroadcastTxInvalidSigLength" --tests "org.tron.core.net.messagehandler.TransactionsMsgHandlerTest.testInvalidSigLength" --tests "org.tron.core.net.services.RelayServiceTest.testCheckHelloMessage"`

**Follow up**

None.
