### PR TITLE
feature: add fastforward hello message latency metric

### DIFF
--- a/common/src/main/java/org/tron/common/prometheus/MetricKeys.java
+++ b/common/src/main/java/org/tron/common/prometheus/MetricKeys.java
@@ -77,6 +77,16 @@ public class MetricKeys {
      */
     public static final String TX_FETCH_LATENCY = "tron:tx_fetch_latency_seconds";
 
+    /**
+     * Handshake round-trip latency in seconds: from TCP connection
+     * establishment to {@code HelloMessage} fully processed.
+     * <p>Sampled only on the SR{@literal <->}FF handshake path — either
+     * the received {@code HelloMessage} carries a witness signature, or
+     * the remote peer is in {@code node.fastForward.nodes}. Regular
+     * FullNode handshakes are not sampled.
+     */
+    public static final String HANDSHAKE_LATENCY = "tron:handshake_latency_seconds";
+
     private Histogram() {
       throw new IllegalStateException("Histogram");
     }

--- a/common/src/main/java/org/tron/common/prometheus/MetricsHistogram.java
+++ b/common/src/main/java/org/tron/common/prometheus/MetricsHistogram.java
@@ -50,6 +50,8 @@ public class MetricsHistogram {
         "receive block delay time, receiveTime - blockTime.");
     init(MetricKeys.Histogram.TX_FETCH_LATENCY,
         "fetch transaction latency: GET_DATA send to full TXS received round-trip.");
+    init(MetricKeys.Histogram.HANDSHAKE_LATENCY,
+        "handshake round-trip latency on the SR<->FF path.");
 
     init(MetricKeys.Histogram.BLOCK_TRANSACTION_COUNT,
         "Distribution of transaction counts per block.",

--- a/framework/src/main/java/org/tron/core/net/service/handshake/HandshakeService.java
+++ b/framework/src/main/java/org/tron/core/net/service/handshake/HandshakeService.java
@@ -4,6 +4,8 @@ import java.util.Arrays;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+import org.tron.common.prometheus.MetricKeys;
+import org.tron.common.prometheus.Metrics;
 import org.tron.common.utils.ByteArray;
 import org.tron.core.ChainBaseManager;
 import org.tron.core.ChainBaseManager.NodeType;
@@ -15,6 +17,7 @@ import org.tron.core.net.peer.PeerManager;
 import org.tron.core.net.service.effective.EffectiveCheckService;
 import org.tron.core.net.service.relay.RelayService;
 import org.tron.p2p.discover.Node;
+import org.tron.protos.Protocol;
 import org.tron.protos.Protocol.ReasonCode;
 
 @Slf4j(topic = "net")
@@ -122,8 +125,17 @@ public class HandshakeService {
 
     peer.setHelloMessageReceive(msg);
 
-    peer.getChannel().updateAvgLatency(
-            System.currentTimeMillis() - peer.getChannel().getStartTime());
+    long latencyMs = System.currentTimeMillis() - peer.getChannel().getStartTime();
+    peer.getChannel().updateAvgLatency(latencyMs);
+    // Sample only the SR<->FF handshake path:
+    //  - inbound:  received hello carries a witness signature.
+    //  - outbound: peer is in node.fastForward.nodes.
+    Protocol.HelloMessage hello = msg.getInstance();
+    boolean signed = !hello.getSignature().isEmpty() || hello.hasPqAuthSig();
+    if (signed || relayService.isFastForwardPeer(peer.getChannel())) {
+      Metrics.histogramObserve(MetricKeys.Histogram.HANDSHAKE_LATENCY,
+          latencyMs / Metrics.MILLISECONDS_PER_SECOND);
+    }
     PeerManager.sortPeers();
     peer.onConnect();
   }

--- a/framework/src/main/java/org/tron/core/net/service/relay/RelayService.java
+++ b/framework/src/main/java/org/tron/core/net/service/relay/RelayService.java
@@ -121,6 +121,22 @@ public class RelayService {
     ExecutorServiceManager.shutdownAndAwaitTermination(executorService, esName);
   }
 
+  /**
+   * Whether the channel's remote peer is in {@code node.fastForward.nodes}.
+   */
+  public boolean isFastForwardPeer(Channel channel) {
+    if (fastForwardNodes.isEmpty() || channel == null
+        || channel.getInetAddress() == null) {
+      return false;
+    }
+    for (InetSocketAddress ff : fastForwardNodes) {
+      if (channel.getInetAddress().equals(ff.getAddress())) {
+        return true;
+      }
+    }
+    return false;
+  }
+
   public void fillHelloMessage(HelloMessage message, Channel channel) {
     if (!isActiveWitness()) {
       return;


### PR DESCRIPTION
**What does this PR do?**

**Why are these changes required?**

**This PR has been tested by:**
- Unit Tests
- Manual Testing

**Follow up**

**Extra details**



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Prometheus histogram to measure handshake round‑trip latency on the SR<->FF path, from TCP connect to HelloMessage processed. This improves visibility into FastForward handshake performance.

- **New Features**
  - Introduced `tron:handshake_latency_seconds` and initialized it in `MetricsHistogram`.
  - Metric is recorded only for SR<->FF handshakes: inbound signed HelloMessage (witness or `pqAuthSig`) or peers listed in `node.fastForward.nodes` (via `RelayService.isFastForwardPeer`).

<sup>Written for commit ea3dc859971b39ae2cdc7601c17f2a4badba4b78. Summary will update on new commits. <a href="https://cubic.dev/pr/Federico2014/java-tron/pull/33?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

