### PR TITLE
refactor(net): truncate oversized signatures

### DIFF
--- a/chainbase/src/main/java/org/tron/core/capsule/BlockCapsule.java
+++ b/chainbase/src/main/java/org/tron/core/capsule/BlockCapsule.java
@@ -15,6 +15,7 @@
 
 package org.tron.core.capsule;
 
+import static org.tron.core.Constant.MAX_PER_SIGN_LENGTH;
 import static org.tron.core.exception.BadBlockException.TypeEnum.CALC_MERKLE_ROOT_FAILED;
 
 import com.google.common.primitives.Longs;
@@ -346,6 +347,18 @@ public class BlockCapsule implements ProtoCapsule<Block> {
           .build());
     }
     this.block = builder.build();
+    return true;
+  }
+
+  public boolean sanitizeSignatures() {
+    ByteString sig = this.block.getBlockHeader().getWitnessSignature();
+    if (sig.size() <= MAX_PER_SIGN_LENGTH) {
+      return false;
+    }
+    BlockHeader header = this.block.getBlockHeader().toBuilder()
+        .setWitnessSignature(sig.substring(0, MAX_PER_SIGN_LENGTH))
+        .build();
+    this.block = this.block.toBuilder().setBlockHeader(header).build();
     return true;
   }
 

--- a/chainbase/src/main/java/org/tron/core/capsule/TransactionCapsule.java
+++ b/chainbase/src/main/java/org/tron/core/capsule/TransactionCapsule.java
@@ -18,6 +18,7 @@ package org.tron.core.capsule;
 import static org.tron.common.utils.StringUtil.encode58Check;
 import static org.tron.common.utils.WalletUtil.checkPermissionOperations;
 import static org.tron.core.Constant.MAX_CONTRACT_RESULT_SIZE;
+import static org.tron.core.Constant.MAX_PER_SIGN_LENGTH;
 import static org.tron.core.exception.P2pException.TypeEnum.PROTOBUF_ERROR;
 
 import com.google.common.primitives.Bytes;
@@ -505,6 +506,30 @@ public class TransactionCapsule implements ProtoCapsule<Transaction> {
     return true;
   }
 
+  public boolean sanitizeSignatures() {
+    List<ByteString> sigs = this.transaction.getSignatureList();
+    boolean changed = false;
+    for (ByteString sig : sigs) {
+      if (sig.size() > MAX_PER_SIGN_LENGTH) {
+        changed = true;
+        break;
+      }
+    }
+    if (!changed) {
+      return false;
+    }
+    Transaction.Builder builder = this.transaction.toBuilder().clearSignature();
+    for (ByteString sig : sigs) {
+      if (sig.size() > MAX_PER_SIGN_LENGTH) {
+        builder.addSignature(sig.substring(0, MAX_PER_SIGN_LENGTH));
+      } else {
+        builder.addSignature(sig);
+      }
+    }
+    this.transaction = builder.build();
+    return true;
+  }
+
   public void resetResult() {
     if (this.getInstance().getRetCount() > 0) {
       this.transaction = this.getInstance().toBuilder().clearRet().build();
@@ -631,7 +656,7 @@ public class TransactionCapsule implements ProtoCapsule<Transaction> {
         .signHash(getTransactionId().getBytes())));
     this.transaction = this.transaction.toBuilder().addSignature(sig).build();
   }
-  
+
   private static void checkPermission(int permissionId, Permission permission, Transaction.Contract contract) throws PermissionException {
     if (permissionId != 0) {
       if (permission.getType() != PermissionType.Active) {
@@ -714,7 +739,7 @@ public class TransactionCapsule implements ProtoCapsule<Transaction> {
         }
       }
       isVerified = true;
-    }  
+    }
     return true;
   }
 

--- a/crypto/src/main/java/org/tron/common/crypto/SignUtils.java
+++ b/crypto/src/main/java/org/tron/common/crypto/SignUtils.java
@@ -1,8 +1,5 @@
 package org.tron.common.crypto;
 
-import static org.tron.core.Constant.MAX_PER_SIGN_LENGTH;
-import static org.tron.core.Constant.PER_SIGN_LENGTH;
-
 import java.security.SecureRandom;
 import java.security.SignatureException;
 import org.tron.common.crypto.ECKey.ECDSASignature;
@@ -10,21 +7,6 @@ import org.tron.common.crypto.sm2.SM2;
 import org.tron.common.crypto.sm2.SM2.SM2Signature;
 
 public class SignUtils {
-
-  /**
-   * Strict signature-length check for admission entry-points (RPC broadcast,
-   * P2P transaction ingress, peer hello handshake). Accepts only sizes in
-   * [{@link org.tron.core.Constant#PER_SIGN_LENGTH PER_SIGN_LENGTH},
-   * {@link org.tron.core.Constant#MAX_PER_SIGN_LENGTH MAX_PER_SIGN_LENGTH}].
-   *
-   * <p>Consensus paths (e.g. {@code TransactionCapsule.checkWeight}) intentionally
-   * keep the looser {@code size < 65} check to remain compatible with historical
-   * on-chain signatures that carry trailing padding bytes; do not call this
-   * helper from those paths.
-   */
-  public static boolean isValidLength(int size) {
-    return size >= PER_SIGN_LENGTH && size <= MAX_PER_SIGN_LENGTH;
-  }
 
   public static SignInterface getGeneratedRandomSign(
       SecureRandom secureRandom, boolean isECKeyCryptoEngine) {

--- a/framework/src/main/java/org/tron/core/Wallet.java
+++ b/framework/src/main/java/org/tron/core/Wallet.java
@@ -505,15 +505,7 @@ public class Wallet {
     trx.setTime(System.currentTimeMillis());
     Sha256Hash txID = trx.getTransactionId();
     try {
-      for (ByteString sig : signedTransaction.getSignatureList()) {
-        if (!SignUtils.isValidLength(sig.size())) {
-          String info = "Signature size is " + sig.size();
-          logger.warn("Broadcast transaction {} has failed, {}.", txID, info);
-          return builder.setResult(false).setCode(response_code.SIGERROR)
-              .setMessage(ByteString.copyFromUtf8("Validate signature error: " + info))
-              .build();
-        }
-      }
+      trx.sanitizeSignatures();
 
       if (tronNetDelegate.isBlockUnsolidified()) {
         logger.warn("Broadcast transaction {} has failed, block unsolidified.", txID);

--- a/framework/src/main/java/org/tron/core/net/message/adv/BlockMessage.java
+++ b/framework/src/main/java/org/tron/core/net/message/adv/BlockMessage.java
@@ -29,7 +29,9 @@ public class BlockMessage extends TronMessage {
   }
 
   public void sanitize() {
-    if (this.block.sanitize()) {
+    boolean unknownStripped = this.block.sanitize();
+    boolean signatureTruncated = this.block.sanitizeSignatures();
+    if (unknownStripped || signatureTruncated) {
       this.data = this.block.getData();
     }
   }

--- a/framework/src/main/java/org/tron/core/net/message/adv/TransactionsMessage.java
+++ b/framework/src/main/java/org/tron/core/net/message/adv/TransactionsMessage.java
@@ -1,5 +1,6 @@
 package org.tron.core.net.message.adv;
 
+import java.util.ArrayList;
 import java.util.List;
 import org.tron.core.capsule.TransactionCapsule;
 import org.tron.core.net.message.MessageTypes;
@@ -31,6 +32,29 @@ public class TransactionsMessage extends TronMessage {
 
   public Protocol.Transactions getTransactions() {
     return transactions;
+  }
+
+  public boolean sanitizeSignature() {
+    List<Transaction> list = transactions.getTransactionsList();
+    boolean changed = false;
+    List<Transaction> sanitized = new ArrayList<>(list.size());
+    for (Transaction trx : list) {
+      TransactionCapsule cap = new TransactionCapsule(trx);
+      if (cap.sanitizeSignatures()) {
+        changed = true;
+        sanitized.add(cap.getInstance());
+      } else {
+        sanitized.add(trx);
+      }
+    }
+    if (!changed) {
+      return false;
+    }
+    Protocol.Transactions.Builder builder = Protocol.Transactions.newBuilder();
+    sanitized.forEach(builder::addTransactions);
+    this.transactions = builder.build();
+    this.data = this.transactions.toByteArray();
+    return true;
   }
 
   @Override

--- a/framework/src/main/java/org/tron/core/net/messagehandler/TransactionsMsgHandler.java
+++ b/framework/src/main/java/org/tron/core/net/messagehandler/TransactionsMsgHandler.java
@@ -1,6 +1,5 @@
 package org.tron.core.net.messagehandler;
 
-import com.google.protobuf.ByteString;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -14,7 +13,6 @@ import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
-import org.tron.common.crypto.SignUtils;
 import org.tron.common.es.ExecutorServiceManager;
 import org.tron.common.utils.Sha256Hash;
 import org.tron.core.ChainBaseManager;
@@ -127,6 +125,7 @@ public class TransactionsMsgHandler implements TronMsgHandler {
   }
 
   private void check(PeerConnection peer, TransactionsMessage msg) throws P2pException {
+    msg.sanitizeSignature();
     List<Transaction> list = msg.getTransactions().getTransactionsList();
     Set<Sha256Hash> seen = new HashSet<>(list.size() * 2);
     for (Transaction trx : list) {
@@ -143,12 +142,6 @@ public class TransactionsMsgHandler implements TronMsgHandler {
       if (trx.getRawData().getContractCount() < 1) {
         throw new P2pException(TypeEnum.BAD_TRX,
             "tx " + item.getHash() + " contract size should be greater than 0");
-      }
-      for (ByteString sig : trx.getSignatureList()) {
-        if (!SignUtils.isValidLength(sig.size())) {
-          throw new P2pException(TypeEnum.BAD_TRX,
-              "tx " + item.getHash() + " signature size is " + sig.size());
-        }
       }
     }
   }

--- a/framework/src/main/java/org/tron/core/net/service/relay/RelayService.java
+++ b/framework/src/main/java/org/tron/core/net/service/relay/RelayService.java
@@ -23,6 +23,7 @@ import org.tron.common.parameter.CommonParameter;
 import org.tron.common.utils.ByteArray;
 import org.tron.common.utils.Sha256Hash;
 import org.tron.core.ChainBaseManager;
+import org.tron.core.Constant;
 import org.tron.core.capsule.TransactionCapsule;
 import org.tron.core.config.args.Args;
 import org.tron.core.db.Manager;
@@ -150,9 +151,10 @@ public class RelayService {
       return false;
     }
 
-    if (!SignUtils.isValidLength(msg.getSignature().size())) {
+    int sigSize = msg.getSignature().size();
+    if (sigSize < Constant.PER_SIGN_LENGTH || sigSize > Constant.MAX_PER_SIGN_LENGTH) {
       logger.warn("HelloMessage from {}, signature size is {}.",
-          channel.getInetAddress(), msg.getSignature().size());
+          channel.getInetAddress(), sigSize);
       return false;
     }
 

--- a/framework/src/test/java/org/tron/core/WalletMockTest.java
+++ b/framework/src/test/java/org/tron/core/WalletMockTest.java
@@ -168,48 +168,21 @@ public class WalletMockTest {
   public void testBroadcastTxInvalidSigLength() throws Exception {
     Wallet wallet = new Wallet();
     TronNetDelegate tronNetDelegateMock = mock(TronNetDelegate.class);
+    when(tronNetDelegateMock.isBlockUnsolidified()).thenReturn(true);
     Field field = wallet.getClass().getDeclaredField("tronNetDelegate");
     field.setAccessible(true);
     field.set(wallet, tronNetDelegateMock);
 
-    // signature shorter than 65 bytes → SIGERROR
-    Protocol.Transaction shortSig = Protocol.Transaction.newBuilder()
-        .addSignature(ByteString.copyFrom(new byte[64]))
-        .build();
-    GrpcAPI.Return ret = wallet.broadcastTransaction(shortSig);
-    assertEquals(GrpcAPI.Return.response_code.SIGERROR, ret.getCode());
-
-    // signature longer than 68 bytes → SIGERROR
-    Protocol.Transaction longSig = Protocol.Transaction.newBuilder()
-        .addSignature(ByteString.copyFrom(new byte[69]))
-        .build();
-    ret = wallet.broadcastTransaction(longSig);
-    assertEquals(GrpcAPI.Return.response_code.SIGERROR, ret.getCode());
-
-    // empty signature → SIGERROR
-    Protocol.Transaction emptySig = Protocol.Transaction.newBuilder()
-        .addSignature(ByteString.EMPTY)
-        .build();
-    ret = wallet.broadcastTransaction(emptySig);
-    assertEquals(GrpcAPI.Return.response_code.SIGERROR, ret.getCode());
-
-    // tronNetDelegate must not be consulted because the request is rejected up front
-    Mockito.verify(tronNetDelegateMock, Mockito.never()).isBlockUnsolidified();
-
-    // 65-byte signature passes the length check and proceeds to downstream logic
-    when(tronNetDelegateMock.isBlockUnsolidified()).thenReturn(true);
-    Protocol.Transaction validSig = Protocol.Transaction.newBuilder()
-        .addSignature(ByteString.copyFrom(new byte[65]))
-        .build();
-    ret = wallet.broadcastTransaction(validSig);
-    assertEquals(GrpcAPI.Return.response_code.BLOCK_UNSOLIDIFIED, ret.getCode());
-
-    // 68-byte signature (upper bound) also passes the length check
-    Protocol.Transaction paddedSig = Protocol.Transaction.newBuilder()
-        .addSignature(ByteString.copyFrom(new byte[68]))
-        .build();
-    ret = wallet.broadcastTransaction(paddedSig);
-    assertEquals(GrpcAPI.Return.response_code.BLOCK_UNSOLIDIFIED, ret.getCode());
+    // Signature length is no longer validated up front — any length proceeds past sanitize and
+    // reaches downstream logic (here: BLOCK_UNSOLIDIFIED stubbed for short-circuit).
+    for (int size : new int[] {0, 64, 65, 68, 69, 200}) {
+      Protocol.Transaction trx = Protocol.Transaction.newBuilder()
+          .addSignature(ByteString.copyFrom(new byte[size]))
+          .build();
+      GrpcAPI.Return ret = wallet.broadcastTransaction(trx);
+      assertEquals("sig size=" + size,
+          GrpcAPI.Return.response_code.BLOCK_UNSOLIDIFIED, ret.getCode());
+    }
   }
 
   @Test

--- a/framework/src/test/java/org/tron/core/net/message/adv/SanitizeSignaturesTest.java
+++ b/framework/src/test/java/org/tron/core/net/message/adv/SanitizeSignaturesTest.java
@@ -8,17 +8,49 @@ import static org.junit.Assert.assertTrue;
 
 import com.google.protobuf.ByteString;
 import java.util.Arrays;
+import org.junit.BeforeClass;
 import org.junit.Test;
+import org.mockito.Mockito;
+import org.tron.common.overlay.message.Message;
+import org.tron.core.capsule.BlockCapsule;
 import org.tron.core.capsule.TransactionCapsule;
+import org.tron.core.store.DynamicPropertiesStore;
+import org.tron.protos.Protocol.Block;
+import org.tron.protos.Protocol.BlockHeader;
 import org.tron.protos.Protocol.Transaction;
 
 /**
- * Verifies that {@link TransactionCapsule#sanitizeSignatures()} and
- * {@link TransactionsMessage#sanitizeSignature()} truncate any signature longer than 68
+ * Verifies that {@link TransactionCapsule#sanitizeSignatures()},
+ * {@link TransactionsMessage#sanitizeSignature()} and
+ * {@link BlockCapsule#sanitizeSignatures()} truncate any signature longer than 68
  * bytes to exactly 68 bytes while leaving in-range signatures (and the
- * transaction id) untouched.
+ * transaction / block id) untouched.
  */
 public class SanitizeSignaturesTest {
+
+  @BeforeClass
+  public static void setUp() {
+    // BlockMessage(byte[]) calls Message.isFilter() which dereferences the
+    // static DynamicPropertiesStore. The mock's primitive-long getter returns
+    // 0L by default, so isFilter() returns false.
+    Message.setDynamicPropertiesStore(Mockito.mock(DynamicPropertiesStore.class));
+  }
+
+  private static BlockHeader.raw sampleRawHeader() {
+    return BlockHeader.raw.newBuilder()
+        .setNumber(100)
+        .setTimestamp(123456789L)
+        .build();
+  }
+
+  private static Block sampleBlock(ByteString witnessSignature) {
+    return Block.newBuilder()
+        .setBlockHeader(BlockHeader.newBuilder()
+            .setRawData(sampleRawHeader())
+            .setWitnessSignature(witnessSignature)
+            .build())
+        .build();
+  }
 
   private static Transaction sampleTransaction() {
     return Transaction.newBuilder()
@@ -141,5 +173,99 @@ public class SanitizeSignaturesTest {
 
     assertFalse(msg.sanitizeSignature());
     assertSame(before, msg.getData());
+  }
+
+  // ---- BlockCapsule.sanitizeSignatures ----
+
+  @Test
+  public void blockCapsuleTruncatesOversizedWitnessSignatureTo68Bytes() {
+    byte[] sigBytes = new byte[200];
+    Arrays.fill(sigBytes, (byte) 0x7f);
+    Block padded = sampleBlock(ByteString.copyFrom(sigBytes));
+    BlockCapsule capsule = new BlockCapsule(padded);
+
+    assertTrue("sanitizeSignatures() should report it mutated the capsule",
+        capsule.sanitizeSignatures());
+    assertEquals(68,
+        capsule.getInstance().getBlockHeader().getWitnessSignature().size());
+    assertArrayEquals("First 68 bytes must be preserved",
+        Arrays.copyOf(sigBytes, 68),
+        capsule.getInstance().getBlockHeader().getWitnessSignature().toByteArray());
+  }
+
+  @Test
+  public void blockCapsuleLeavesSixtyFiveByteWitnessSignatureUnchanged() {
+    Block clean = sampleBlock(ByteString.copyFrom(new byte[65]));
+    BlockCapsule capsule = new BlockCapsule(clean);
+    Block before = capsule.getInstance();
+
+    assertFalse(capsule.sanitizeSignatures());
+    assertSame(before, capsule.getInstance());
+  }
+
+  @Test
+  public void blockCapsuleLeavesSixtyEightByteWitnessSignatureUnchanged() {
+    Block clean = sampleBlock(ByteString.copyFrom(new byte[68]));
+    BlockCapsule capsule = new BlockCapsule(clean);
+    Block before = capsule.getInstance();
+
+    assertFalse(capsule.sanitizeSignatures());
+    assertSame(before, capsule.getInstance());
+  }
+
+  @Test
+  public void blockCapsuleLeavesUndersizedWitnessSignatureUnchanged() {
+    Block clean = sampleBlock(ByteString.copyFrom(new byte[64]));
+    BlockCapsule capsule = new BlockCapsule(clean);
+    Block before = capsule.getInstance();
+
+    assertFalse(capsule.sanitizeSignatures());
+    assertSame(before, capsule.getInstance());
+    assertEquals(64,
+        capsule.getInstance().getBlockHeader().getWitnessSignature().size());
+  }
+
+  @Test
+  public void blockCapsulePreservesBlockId() {
+    Block clean = sampleBlock(ByteString.copyFrom(new byte[65]));
+    Block padded = sampleBlock(ByteString.copyFrom(new byte[200]));
+    BlockCapsule cleanCapsule = new BlockCapsule(clean);
+    BlockCapsule paddedCapsule = new BlockCapsule(padded);
+
+    paddedCapsule.sanitizeSignatures();
+
+    assertEquals("Truncating witness signature must not change the block id",
+        cleanCapsule.getBlockId(), paddedCapsule.getBlockId());
+  }
+
+  // ---- BlockMessage.sanitize for oversized witness signature ----
+
+  @Test
+  public void blockMessageSanitizeRewritesOversizedWitnessSignatureAndWireBytes()
+      throws Exception {
+    Block padded = sampleBlock(ByteString.copyFrom(new byte[200]));
+    byte[] paddedBytes = padded.toByteArray();
+    BlockMessage msg = new BlockMessage(paddedBytes);
+
+    msg.sanitize();
+
+    assertEquals(68,
+        msg.getBlockCapsule().getInstance().getBlockHeader().getWitnessSignature().size());
+    assertTrue("Wire data should shrink after truncating",
+        msg.getData().length < paddedBytes.length);
+    assertArrayEquals("msg.data should equal capsule.getData() after sanitize",
+        msg.getBlockCapsule().getData(), msg.getData());
+  }
+
+  @Test
+  public void blockMessageSanitizeIsNoOpWhenWitnessSignatureInRange() throws Exception {
+    byte[] cleanBytes = sampleBlock(ByteString.copyFrom(new byte[65])).toByteArray();
+    BlockMessage msg = new BlockMessage(cleanBytes);
+    byte[] before = msg.getData();
+
+    msg.sanitize();
+
+    assertSame("msg.data should not be rewritten on the no-op path",
+        before, msg.getData());
   }
 }

--- a/framework/src/test/java/org/tron/core/net/message/adv/SanitizeSignaturesTest.java
+++ b/framework/src/test/java/org/tron/core/net/message/adv/SanitizeSignaturesTest.java
@@ -1,0 +1,145 @@
+package org.tron.core.net.message.adv;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
+import com.google.protobuf.ByteString;
+import java.util.Arrays;
+import org.junit.Test;
+import org.tron.core.capsule.TransactionCapsule;
+import org.tron.protos.Protocol.Transaction;
+
+/**
+ * Verifies that {@link TransactionCapsule#sanitizeSignatures()} and
+ * {@link TransactionsMessage#sanitizeSignature()} truncate any signature longer than 68
+ * bytes to exactly 68 bytes while leaving in-range signatures (and the
+ * transaction id) untouched.
+ */
+public class SanitizeSignaturesTest {
+
+  private static Transaction sampleTransaction() {
+    return Transaction.newBuilder()
+        .setRawData(Transaction.raw.newBuilder().setTimestamp(123456789L).build())
+        .build();
+  }
+
+  // ---- TransactionCapsule.sanitizeSignatures ----
+
+  @Test
+  public void truncatesOversizedSignatureTo68Bytes() {
+    byte[] sigBytes = new byte[200];
+    Arrays.fill(sigBytes, (byte) 0x7f);
+    Transaction padded = sampleTransaction().toBuilder()
+        .addSignature(ByteString.copyFrom(sigBytes))
+        .build();
+    TransactionCapsule capsule = new TransactionCapsule(padded);
+
+    assertTrue("sanitizeSignatures() should report it mutated the capsule",
+        capsule.sanitizeSignatures());
+    assertEquals(68, capsule.getInstance().getSignature(0).size());
+    assertArrayEquals("First 68 bytes must be preserved",
+        Arrays.copyOf(sigBytes, 68),
+        capsule.getInstance().getSignature(0).toByteArray());
+  }
+
+  @Test
+  public void leavesSixtyFiveByteSignatureUnchanged() {
+    Transaction trx = sampleTransaction().toBuilder()
+        .addSignature(ByteString.copyFrom(new byte[65]))
+        .build();
+    TransactionCapsule capsule = new TransactionCapsule(trx);
+    Transaction before = capsule.getInstance();
+
+    assertFalse(capsule.sanitizeSignatures());
+    assertSame(before, capsule.getInstance());
+  }
+
+  @Test
+  public void leavesSixtyEightByteSignatureUnchanged() {
+    Transaction trx = sampleTransaction().toBuilder()
+        .addSignature(ByteString.copyFrom(new byte[68]))
+        .build();
+    TransactionCapsule capsule = new TransactionCapsule(trx);
+    Transaction before = capsule.getInstance();
+
+    assertFalse(capsule.sanitizeSignatures());
+    assertSame(before, capsule.getInstance());
+  }
+
+  @Test
+  public void leavesUndersizedSignatureUnchanged() {
+    Transaction trx = sampleTransaction().toBuilder()
+        .addSignature(ByteString.copyFrom(new byte[64]))
+        .build();
+    TransactionCapsule capsule = new TransactionCapsule(trx);
+    Transaction before = capsule.getInstance();
+
+    assertFalse(capsule.sanitizeSignatures());
+    assertSame(before, capsule.getInstance());
+    assertEquals(64, capsule.getInstance().getSignature(0).size());
+  }
+
+  @Test
+  public void truncatesOnlyOversizedSignaturesInMixedList() {
+    Transaction trx = sampleTransaction().toBuilder()
+        .addSignature(ByteString.copyFrom(new byte[65]))
+        .addSignature(ByteString.copyFrom(new byte[100]))
+        .addSignature(ByteString.copyFrom(new byte[68]))
+        .build();
+    TransactionCapsule capsule = new TransactionCapsule(trx);
+
+    assertTrue(capsule.sanitizeSignatures());
+    assertEquals(65, capsule.getInstance().getSignature(0).size());
+    assertEquals(68, capsule.getInstance().getSignature(1).size());
+    assertEquals(68, capsule.getInstance().getSignature(2).size());
+  }
+
+  @Test
+  public void preservesTransactionId() {
+    Transaction clean = sampleTransaction().toBuilder()
+        .addSignature(ByteString.copyFrom(new byte[65]))
+        .build();
+    Transaction padded = sampleTransaction().toBuilder()
+        .addSignature(ByteString.copyFrom(new byte[200]))
+        .build();
+    TransactionCapsule cleanCapsule = new TransactionCapsule(clean);
+    TransactionCapsule paddedCapsule = new TransactionCapsule(padded);
+
+    paddedCapsule.sanitizeSignatures();
+
+    assertEquals("Truncating signatures must not change the transaction id",
+        cleanCapsule.getTransactionId(), paddedCapsule.getTransactionId());
+  }
+
+  // ---- TransactionsMessage.sanitizeSignature ----
+
+  @Test
+  public void messageSanitizeRewritesAffectedTransactionAndWireBytes() {
+    Transaction oversized = sampleTransaction().toBuilder()
+        .addSignature(ByteString.copyFrom(new byte[200]))
+        .build();
+    TransactionsMessage msg = new TransactionsMessage(Arrays.asList(oversized));
+    byte[] before = msg.getData();
+
+    assertTrue(msg.sanitizeSignature());
+    assertEquals(68, msg.getTransactions().getTransactions(0).getSignature(0).size());
+    assertTrue("Wire data should shrink after truncating",
+        msg.getData().length < before.length);
+    assertArrayEquals(msg.getTransactions().toByteArray(), msg.getData());
+  }
+
+  @Test
+  public void messageSanitizeIsNoOpWhenAllSignaturesInRange() {
+    Transaction inRange = sampleTransaction().toBuilder()
+        .addSignature(ByteString.copyFrom(new byte[65]))
+        .build();
+    TransactionsMessage msg = new TransactionsMessage(Arrays.asList(inRange));
+    byte[] before = msg.getData();
+
+    assertFalse(msg.sanitizeSignature());
+    assertSame(before, msg.getData());
+  }
+}

--- a/framework/src/test/java/org/tron/core/net/messagehandler/TransactionsMsgHandlerTest.java
+++ b/framework/src/test/java/org/tron/core/net/messagehandler/TransactionsMsgHandlerTest.java
@@ -231,7 +231,7 @@ public class TransactionsMsgHandlerTest extends BaseTest {
           Protocol.Inventory.InventoryType.TRX);
       advInvRequest.put(item, 0L);
     }
-    Mockito.when(peer.getAdvInvRequest()).thenReturn(advInvRequest);
+    Mockito.doReturn(advInvRequest).when(peer).getAdvInvRequest();
   }
 
   @Test
@@ -343,6 +343,8 @@ public class TransactionsMsgHandlerTest extends BaseTest {
     handler.init();
     try {
       PeerConnection peer = Mockito.mock(PeerConnection.class);
+      // Short-circuit async handleTransaction so it doesn't race with later stubbing.
+      Mockito.doReturn(true).when(peer).isBadPeer();
 
       BalanceContract.TransferContract transferContract = BalanceContract.TransferContract
           .newBuilder()
@@ -351,24 +353,6 @@ public class TransactionsMsgHandlerTest extends BaseTest {
           .setToAddress(ByteString.copyFrom(ByteArray.fromHexString("232323a9cf")))
           .build();
 
-      // signature shorter than 65 bytes → BAD_TRX
-      Protocol.Transaction shortSigTrx = Protocol.Transaction.newBuilder()
-          .setRawData(Protocol.Transaction.raw.newBuilder()
-              .addContract(Protocol.Transaction.Contract.newBuilder()
-                  .setType(Protocol.Transaction.Contract.ContractType.TransferContract)
-                  .setParameter(Any.pack(transferContract)).build())
-              .build())
-          .addSignature(ByteString.copyFrom(new byte[64]))
-          .build();
-
-      List<Protocol.Transaction> shortList = new ArrayList<>();
-      shortList.add(shortSigTrx);
-      stubAdvInvRequest(peer, new TransactionsMessage(shortList));
-      P2pException shortEx = Assert.assertThrows(P2pException.class,
-          () -> handler.processMessage(peer, new TransactionsMessage(shortList)));
-      Assert.assertEquals(TypeEnum.BAD_TRX, shortEx.getType());
-
-      // signature longer than 68 bytes → BAD_TRX
       Protocol.Transaction longSigTrx = Protocol.Transaction.newBuilder()
           .setRawData(Protocol.Transaction.raw.newBuilder()
               .setRefBlockNum(1)
@@ -378,15 +362,15 @@ public class TransactionsMsgHandlerTest extends BaseTest {
               .build())
           .addSignature(ByteString.copyFrom(new byte[69]))
           .build();
-
-      List<Protocol.Transaction> longList = new ArrayList<>();
-      longList.add(longSigTrx);
-      stubAdvInvRequest(peer, new TransactionsMessage(longList));
-      P2pException longEx = Assert.assertThrows(P2pException.class,
-          () -> handler.processMessage(peer, new TransactionsMessage(longList)));
-      Assert.assertEquals(TypeEnum.BAD_TRX, longEx.getType());
-
-      // exactly 65 bytes → passes the length check (no P2pException from check)
+      Protocol.Transaction veryLongSigTrx = Protocol.Transaction.newBuilder()
+          .setRawData(Protocol.Transaction.raw.newBuilder()
+              .setRefBlockNum(4)
+              .addContract(Protocol.Transaction.Contract.newBuilder()
+                  .setType(Protocol.Transaction.Contract.ContractType.TransferContract)
+                  .setParameter(Any.pack(transferContract)).build())
+              .build())
+          .addSignature(ByteString.copyFrom(new byte[200]))
+          .build();
       Protocol.Transaction validSigTrx = Protocol.Transaction.newBuilder()
           .setRawData(Protocol.Transaction.raw.newBuilder()
               .setRefBlockNum(2)
@@ -396,13 +380,6 @@ public class TransactionsMsgHandlerTest extends BaseTest {
               .build())
           .addSignature(ByteString.copyFrom(new byte[65]))
           .build();
-
-      List<Protocol.Transaction> validList = new ArrayList<>();
-      validList.add(validSigTrx);
-      stubAdvInvRequest(peer, new TransactionsMessage(validList));
-      handler.processMessage(peer, new TransactionsMessage(validList));
-
-      // 68 bytes (upper bound) also passes the length check
       Protocol.Transaction paddedSigTrx = Protocol.Transaction.newBuilder()
           .setRawData(Protocol.Transaction.raw.newBuilder()
               .setRefBlockNum(3)
@@ -413,10 +390,41 @@ public class TransactionsMsgHandlerTest extends BaseTest {
           .addSignature(ByteString.copyFrom(new byte[68]))
           .build();
 
-      List<Protocol.Transaction> paddedList = new ArrayList<>();
-      paddedList.add(paddedSigTrx);
-      stubAdvInvRequest(peer, new TransactionsMessage(paddedList));
-      handler.processMessage(peer, new TransactionsMessage(paddedList));
+      // Stub once with a map containing every test case's item; re-populate before each call so
+      // the in-place removal done by processMessage doesn't affect later cases.
+      Map<Item, Long> advInvRequest = new ConcurrentHashMap<>();
+      Mockito.doReturn(advInvRequest).when(peer).getAdvInvRequest();
+      java.util.function.Consumer<Protocol.Transaction> primeInv = trx -> {
+        Item item = new Item(new TransactionMessage(trx).getMessageId(),
+            Protocol.Inventory.InventoryType.TRX);
+        advInvRequest.put(item, 0L);
+      };
+
+      // signature longer than 68 bytes is truncated to 68 and accepted
+      primeInv.accept(longSigTrx);
+      TransactionsMessage longMsg = new TransactionsMessage(
+          new ArrayList<>(java.util.Collections.singletonList(longSigTrx)));
+      handler.processMessage(peer, longMsg);
+      Assert.assertEquals(68,
+          longMsg.getTransactions().getTransactions(0).getSignature(0).size());
+
+      // signature far longer than 68 bytes is also truncated to 68
+      primeInv.accept(veryLongSigTrx);
+      TransactionsMessage veryLongMsg = new TransactionsMessage(
+          new ArrayList<>(java.util.Collections.singletonList(veryLongSigTrx)));
+      handler.processMessage(peer, veryLongMsg);
+      Assert.assertEquals(68,
+          veryLongMsg.getTransactions().getTransactions(0).getSignature(0).size());
+
+      // exactly 65 bytes → passes the length check
+      primeInv.accept(validSigTrx);
+      handler.processMessage(peer, new TransactionsMessage(
+          new ArrayList<>(java.util.Collections.singletonList(validSigTrx))));
+
+      // 68 bytes (upper bound) also passes the length check
+      primeInv.accept(paddedSigTrx);
+      handler.processMessage(peer, new TransactionsMessage(
+          new ArrayList<>(java.util.Collections.singletonList(paddedSigTrx))));
     } finally {
       handler.close();
     }


### PR DESCRIPTION
**What does this PR do?**

Follow-up to #6782. For transaction signatures longer than 68 bytes, truncate the trailing bytes to exactly 68 instead of rejecting the transaction. Signatures shorter than 65 bytes are no longer rejected up front — they fall through to downstream signature verification, which still rejects them.

- `TransactionCapsule.sanitizeSignatures()` truncates each oversized signature to 68 bytes; signatures already in range are untouched (no rebuild, no transaction-id change).
- `TransactionsMessage.sanitizeSignature()` sanitizes every contained transaction and rewrites the wire bytes when anything changed.
- `Wallet.broadcastTransaction` and `TransactionsMsgHandler.check` call sanitize first, then drop the now-redundant per-signature length validation.
- `RelayService` (peer hello handshake) keeps the strict `[65, 68]` check inline; `SignUtils.isValidLength` is removed since no caller remains.

**Why are these changes required?**

The strict admission filter from #6782 also rejects historical transactions whose signatures legitimately carry trailing padding beyond 68 bytes. Truncating those bytes preserves the canonical 65-byte r/s/v while still admitting the transaction, matching the sanitize pattern introduced in #6797.

**This PR has been tested by:**
- Unit Tests
  - new `SanitizeSignaturesTest` (capsule + message-level, 8 cases)
  - updated `WalletMockTest.testBroadcastTxInvalidSigLength`
  - updated `TransactionsMsgHandlerTest.testInvalidSigLength`
- `./gradlew :framework:checkstyleMain :framework:checkstyleTest`

**Follow up**

None.

**Extra details**

Peer hello handshake (`RelayService`) intentionally stays strict — hello signatures are not on the transaction admission path and have no historical padding to accommodate.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Truncate transaction and block witness signatures longer than 68 bytes at admission instead of rejecting them to restore compatibility with historical data. Upfront length checks are removed; undersized signatures still fail during downstream verification.

- **Refactors**
  - Add sanitize in TransactionCapsule to trim each signature to 68 bytes; in-range signatures are untouched and txid stays the same.
  - Add sanitize in TransactionsMessage and rewrite wire bytes only when changed.
  - Add sanitize in BlockCapsule to trim witness signature to 68 bytes; update BlockMessage.sanitize to rewrite data only when changed; block id unchanged.
  - Call sanitize in Wallet.broadcastTransaction and TransactionsMsgHandler; remove redundant per-signature length checks.
  - Keep strict [65, 68] check in RelayService hello; remove SignUtils.isValidLength.

<sup>Written for commit 0002cc6d8a3e66932ea051c133c5ca70a3dc0450. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Federico2014/java-tron/pull/34?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

