### PR TITLE
fix(api): bound and truncate sign api signatures

### DIFF
--- a/actuator/src/main/java/org/tron/core/utils/TransactionUtil.java
+++ b/actuator/src/main/java/org/tron/core/utils/TransactionUtil.java
@@ -184,6 +184,7 @@ public class TransactionUtil {
   }
 
   public TransactionSignWeight getTransactionSignWeight(Transaction trx) {
+    trx = TransactionCapsule.truncateSignatures(trx);
     TransactionSignWeight.Builder tswBuilder = TransactionSignWeight.newBuilder();
     TransactionExtention.Builder trxExBuilder = TransactionExtention.newBuilder();
     trxExBuilder.setTransaction(trx);

--- a/chainbase/src/main/java/org/tron/core/capsule/TransactionCapsule.java
+++ b/chainbase/src/main/java/org/tron/core/capsule/TransactionCapsule.java
@@ -18,6 +18,7 @@ package org.tron.core.capsule;
 import static org.tron.common.utils.StringUtil.encode58Check;
 import static org.tron.common.utils.WalletUtil.checkPermissionOperations;
 import static org.tron.core.Constant.MAX_CONTRACT_RESULT_SIZE;
+import static org.tron.core.Constant.PER_SIGN_LENGTH;
 import static org.tron.core.exception.P2pException.TypeEnum.PROTOBUF_ERROR;
 
 import com.google.common.primitives.Bytes;
@@ -465,6 +466,25 @@ public class TransactionCapsule implements ProtoCapsule<Transaction> {
     return ECDSASignature.fromComponents(rsv.getR(), rsv.getS(), rsv.getV()).toBase64();
   }
 
+  public static Transaction truncateSignatures(Transaction trx) {
+    boolean needTruncate = false;
+    for (ByteString sig : trx.getSignatureList()) {
+      if (sig.size() > PER_SIGN_LENGTH) {
+        needTruncate = true;
+        break;
+      }
+    }
+    if (!needTruncate) {
+      return trx;
+    }
+    Transaction.Builder builder = trx.toBuilder().clearSignature();
+    for (ByteString sig : trx.getSignatureList()) {
+      builder.addSignature(
+          sig.size() > PER_SIGN_LENGTH ? sig.substring(0, PER_SIGN_LENGTH) : sig);
+    }
+    return builder.build();
+  }
+
   public static boolean validateSignature(Transaction transaction,
       byte[] hash, AccountStore accountStore, DynamicPropertiesStore dynamicPropertiesStore)
       throws PermissionException, SignatureException, SignatureFormatException {
@@ -631,7 +651,7 @@ public class TransactionCapsule implements ProtoCapsule<Transaction> {
         .signHash(getTransactionId().getBytes())));
     this.transaction = this.transaction.toBuilder().addSignature(sig).build();
   }
-  
+
   private static void checkPermission(int permissionId, Permission permission, Transaction.Contract contract) throws PermissionException {
     if (permissionId != 0) {
       if (permission.getType() != PermissionType.Active) {
@@ -714,7 +734,7 @@ public class TransactionCapsule implements ProtoCapsule<Transaction> {
         }
       }
       isVerified = true;
-    }  
+    }
     return true;
   }
 

--- a/framework/src/main/java/org/tron/core/Wallet.java
+++ b/framework/src/main/java/org/tron/core/Wallet.java
@@ -228,6 +228,8 @@ import org.tron.protos.Protocol.MarketOrderList;
 import org.tron.protos.Protocol.MarketOrderPairList;
 import org.tron.protos.Protocol.MarketPrice;
 import org.tron.protos.Protocol.MarketPriceList;
+import org.tron.protos.Protocol.Permission;
+import org.tron.protos.Protocol.Permission.PermissionType;
 import org.tron.protos.Protocol.Proposal;
 import org.tron.protos.Protocol.Transaction;
 import org.tron.protos.Protocol.Transaction.Contract;
@@ -627,6 +629,7 @@ public class Wallet {
   }
 
   public TransactionApprovedList getTransactionApprovedList(Transaction trx) {
+    trx = TransactionCapsule.truncateSignatures(trx);
     TransactionApprovedList.Builder tswBuilder = TransactionApprovedList.newBuilder();
     TransactionExtention.Builder trxExBuilder = TransactionExtention.newBuilder();
     trxExBuilder.setTransaction(trx);
@@ -650,21 +653,26 @@ public class Wallet {
         if (account == null) {
           throw new PermissionException("Account does not exist!");
         }
+        int permissionId = contract.getPermissionId();
+        Permission permission = account.getPermissionById(permissionId);
+        if (permission == null) {
+          throw new PermissionException("Permission for this, does not exist!");
+        }
+        if (permissionId != 0) {
+          if (permission.getType() != PermissionType.Active) {
+            throw new PermissionException("Permission type is wrong!");
+          }
+          //check operations
+          if (!WalletUtil.checkPermissionOperations(permission, contract)) {
+            throw new PermissionException("Permission denied!");
+          }
+        }
 
         if (trx.getSignatureCount() > 0) {
           List<ByteString> approveList = new ArrayList<ByteString>();
           byte[] hash = Sha256Hash.hash(CommonParameter
               .getInstance().isECKeyCryptoEngine(), trx.getRawData().toByteArray());
-          for (ByteString sig : trx.getSignatureList()) {
-            if (sig.size() < 65) {
-              throw new SignatureFormatException(
-                  "Signature size is " + sig.size());
-            }
-            String base64 = TransactionCapsule.getBase64FromByteString(sig);
-            byte[] address = SignUtils.signatureToAddress(hash, base64, Args.getInstance()
-                .isECKeyCryptoEngine());
-            approveList.add(ByteString.copyFrom(address)); //out put approve list.
-          }
+          TransactionCapsule.checkWeight(permission, trx.getSignatureList(), hash, approveList);
           tswBuilder.addAllApprovedList(approveList);
         }
         resultBuilder.setCode(TransactionApprovedList.Result.response_code.SUCCESS);

--- a/framework/src/test/java/org/tron/core/WalletTest.java
+++ b/framework/src/test/java/org/tron/core/WalletTest.java
@@ -1440,5 +1440,96 @@ public class WalletTest extends BaseTest {
     Block block = wallet.getSolidBlock();
     assertEquals(block2, block);
   }
+
+  @Test
+  public void testGetTransactionApprovedListSignatureBound() {
+    ECKey ecKey = new ECKey(Utils.getRandom());
+    AccountCapsule owner = new AccountCapsule(
+        ByteString.copyFromUtf8("approved-owner"),
+        ByteString.copyFrom(ecKey.getAddress()),
+        Protocol.AccountType.Normal,
+        initBalance);
+    chainBaseManager.getAccountStore().put(ecKey.getAddress(), owner);
+    // Default owner permission: a single key with weight 1, so keysCount == 1.
+    int keysCount = owner.getPermissionById(0).getKeysCount();
+    assertEquals(1, keysCount);
+
+    Transaction unsigned = Transaction.newBuilder().setRawData(
+        Transaction.raw.newBuilder().addContract(
+            Contract.newBuilder().setType(ContractType.TransferContract)
+                .setParameter(Any.pack(TransferContract.newBuilder().setAmount(1)
+                    .setOwnerAddress(ByteString.copyFrom(ecKey.getAddress()))
+                    .setToAddress(ByteString.copyFrom(
+                        ByteArray.fromHexString(RECEIVER_ADDRESS)))
+                    .build())).build()).build()).build();
+
+    // One valid 65-byte [r][s][recId] signature by the owner.
+    TransactionCapsule capsule = new TransactionCapsule(unsigned);
+    capsule.sign(ecKey.getPrivKeyBytes());
+    ByteString oneSig = capsule.getInstance().getSignature(0);
+
+    // Within keysCount: the single valid signature is recovered, result is SUCCESS.
+    GrpcAPI.TransactionApprovedList okList = wallet.getTransactionApprovedList(
+        unsigned.toBuilder().addSignature(oneSig).build());
+    assertEquals(GrpcAPI.TransactionApprovedList.Result.response_code.SUCCESS,
+        okList.getResult().getCode());
+    assertEquals(1, okList.getApprovedListCount());
+
+    // More signatures than keysCount: checkWeight rejects before recovering any of them,
+    // so the unbounded ecrecover loop can no longer be triggered.
+    Transaction.Builder overLimit = unsigned.toBuilder();
+    for (int i = 0; i < keysCount + 1; i++) {
+      overLimit.addSignature(oneSig);
+    }
+    GrpcAPI.TransactionApprovedList rejected =
+        wallet.getTransactionApprovedList(overLimit.build());
+    assertEquals(GrpcAPI.TransactionApprovedList.Result.response_code.OTHER_ERROR,
+        rejected.getResult().getCode());
+    assertEquals(0, rejected.getApprovedListCount());
+    Assert.assertTrue(rejected.getResult().getMessage().contains("more than key counts"));
+  }
+
+  @Test
+  public void testGetTransactionApprovedListTruncatesOversizedSignature() {
+    ECKey ecKey = new ECKey(Utils.getRandom());
+    AccountCapsule owner = new AccountCapsule(
+        ByteString.copyFromUtf8("approved-owner-trunc"),
+        ByteString.copyFrom(ecKey.getAddress()),
+        Protocol.AccountType.Normal,
+        initBalance);
+    chainBaseManager.getAccountStore().put(ecKey.getAddress(), owner);
+
+    Transaction unsigned = Transaction.newBuilder().setRawData(
+        Transaction.raw.newBuilder().addContract(
+            Contract.newBuilder().setType(ContractType.TransferContract)
+                .setParameter(Any.pack(TransferContract.newBuilder().setAmount(1)
+                    .setOwnerAddress(ByteString.copyFrom(ecKey.getAddress()))
+                    .setToAddress(ByteString.copyFrom(
+                        ByteArray.fromHexString(RECEIVER_ADDRESS)))
+                    .build())).build()).build()).build();
+
+    TransactionCapsule capsule = new TransactionCapsule(unsigned);
+    capsule.sign(ecKey.getPrivKeyBytes());
+    ByteString validSig = capsule.getInstance().getSignature(0);
+    assertEquals(65, validSig.size());
+
+    // Pad the 65-byte signature with trailing junk bytes.
+    ByteString oversized = validSig.concat(
+        ByteString.copyFrom(new byte[] {1, 2, 3, 4, 5}));
+    assertEquals(70, oversized.size());
+
+    GrpcAPI.TransactionApprovedList reply = wallet.getTransactionApprovedList(
+        unsigned.toBuilder().addSignature(oversized).build());
+
+    // Recovery still succeeds and resolves the owner.
+    assertEquals(GrpcAPI.TransactionApprovedList.Result.response_code.SUCCESS,
+        reply.getResult().getCode());
+    assertEquals(1, reply.getApprovedListCount());
+    // The echoed-back transaction has the signature truncated to 65 bytes.
+    Transaction echoed = reply.getTransaction().getTransaction();
+    assertEquals(1, echoed.getSignatureCount());
+    assertEquals(65, echoed.getSignature(0).size());
+    assertEquals(validSig, echoed.getSignature(0));
+  }
 }
 

--- a/framework/src/test/java/org/tron/core/actuator/utils/TransactionUtilTest.java
+++ b/framework/src/test/java/org/tron/core/actuator/utils/TransactionUtilTest.java
@@ -13,18 +13,23 @@ import static org.tron.core.utils.TransactionUtil.validAccountName;
 import static org.tron.core.utils.TransactionUtil.validAssetName;
 import static org.tron.core.utils.TransactionUtil.validTokenAbbrName;
 
+import com.google.protobuf.Any;
 import com.google.protobuf.ByteString;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
+import javax.annotation.Resource;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.tron.api.GrpcAPI.TransactionSignWeight;
 import org.tron.common.BaseTest;
 import org.tron.common.TestConstants;
+import org.tron.common.crypto.ECKey;
 import org.tron.common.utils.ByteArray;
+import org.tron.common.utils.Utils;
 import org.tron.core.ChainBaseManager;
 import org.tron.core.Constant;
 import org.tron.core.Wallet;
@@ -36,13 +41,18 @@ import org.tron.core.utils.TransactionUtil;
 import org.tron.protos.Protocol;
 import org.tron.protos.Protocol.AccountType;
 import org.tron.protos.Protocol.Transaction;
+import org.tron.protos.Protocol.Transaction.Contract;
 import org.tron.protos.Protocol.Transaction.Contract.ContractType;
 import org.tron.protos.contract.BalanceContract.DelegateResourceContract;
+import org.tron.protos.contract.BalanceContract.TransferContract;
 
 @Slf4j(topic = "capsule")
 public class TransactionUtilTest extends BaseTest {
 
   private static String OWNER_ADDRESS;
+
+  @Resource
+  private TransactionUtil transactionUtil;
 
   /**
    * Init .
@@ -451,5 +461,48 @@ public class TransactionUtilTest extends BaseTest {
       threadList.get(i).join();
     }
     Assert.assertTrue(true);
+  }
+
+  @Test
+  public void testGetTransactionSignWeightTruncatesOversizedSignature() {
+    ECKey ecKey = new ECKey(Utils.getRandom());
+    AccountCapsule owner = new AccountCapsule(
+        ByteString.copyFromUtf8("sign-weight-owner"),
+        ByteString.copyFrom(ecKey.getAddress()),
+        AccountType.Normal,
+        10_000_000_000L);
+    chainBaseManager.getAccountStore().put(ecKey.getAddress(), owner);
+
+    Transaction unsigned = Transaction.newBuilder().setRawData(
+        Transaction.raw.newBuilder().addContract(
+            Contract.newBuilder().setType(ContractType.TransferContract)
+                .setParameter(Any.pack(TransferContract.newBuilder().setAmount(1)
+                    .setOwnerAddress(ByteString.copyFrom(ecKey.getAddress()))
+                    .setToAddress(ByteString.copyFrom(
+                        ByteArray.fromHexString(OWNER_ADDRESS)))
+                    .build())).build()).build()).build();
+
+    TransactionCapsule capsule = new TransactionCapsule(unsigned);
+    capsule.sign(ecKey.getPrivKeyBytes());
+    ByteString validSig = capsule.getInstance().getSignature(0);
+    assertEquals(65, validSig.size());
+
+    // Pad the 65-byte signature with trailing junk bytes.
+    ByteString oversized = validSig.concat(
+        ByteString.copyFrom(new byte[] {1, 2, 3, 4, 5}));
+    assertEquals(70, oversized.size());
+
+    TransactionSignWeight reply = transactionUtil.getTransactionSignWeight(
+        unsigned.toBuilder().addSignature(oversized).build());
+
+    // Recovery still resolves the owner (weight reached the default threshold).
+    assertEquals(TransactionSignWeight.Result.response_code.ENOUGH_PERMISSION,
+        reply.getResult().getCode());
+    assertEquals(1, reply.getApprovedListCount());
+    // The echoed-back transaction has the signature truncated to 65 bytes.
+    Transaction echoed = reply.getTransaction().getTransaction();
+    assertEquals(1, echoed.getSignatureCount());
+    assertEquals(65, echoed.getSignature(0).size());
+    assertEquals(validSig, echoed.getSignature(0));
   }
 }


### PR DESCRIPTION
## What does this PR do?

Hardens the two read-only signature APIs — `getTransactionApprovedList` (`/wallet/getapprovedlist`, gRPC `getTransactionApprovedList`) and `getTransactionSignWeight` — against unbounded signature recovery, and normalizes oversized signatures in the echoed-back transaction.

**1. Bound the recovery loop (CPU DoS fix)**

`Wallet.getTransactionApprovedList` previously ran a hand-rolled loop that called `ecrecover` once per signature in the request, with no cap on the number of signatures — the only per-signature guard was `sig.size() < 65`. An unauthenticated caller could attach tens of thousands of signatures (bounded only by the ~4MiB frame, ≈60k signatures) and force the node to spend seconds of single-core CPU per request, replicating a single valid signature N times.

The loop is now replaced by a delegation to `TransactionCapsule.checkWeight`, exactly mirroring `getTransactionSignWeight`: the method resolves the permission (`getPermissionById` + the active-permission / operations checks) and `checkWeight` rejects up front when `sigs.size() > permission.getKeysCount()`, before recovering any signature. This is the same bound the consensus signature-verification path already enforces.

**2. Truncate oversized signatures (≤ `PER_SIGN_LENGTH`)**

A signature longer than 65 bytes carries only meaningless trailing padding — `Rsv.fromSignature` reads just the first 65 bytes (`[r][s][recId]`) for recovery. A new shared helper `TransactionCapsule.truncateSignatures(trx)` truncates any over-65-byte signature to its first 65 bytes in the echoed-back transaction, keeping the returned signatures canonical. It is applied at the entry of both `getTransactionApprovedList` and `getTransactionSignWeight`. Signatures of 65 bytes or shorter are untouched, and the helper returns the original transaction unchanged when no truncation is needed.

## Why are these changes required?

`getTransactionApprovedList` was the only signature-recovery path that did not bound the signature count. Every sibling path caps it before recovery (`checkWeight` via `permission.getKeysCount()`, `validatePubSignature` via `getTotalSignNum()`), so a single unauthenticated request could trigger an unbounded number of `ecrecover` calls (~12000× amplification over a legal ≤5-signature request) and exhaust CPU / API worker threads. Aligning this endpoint with `getTransactionSignWeight` closes the gap. The signature truncation ensures both APIs return clean, canonical 65-byte signatures rather than echoing back attacker-supplied padding.

## This PR has been tested by

**Unit Tests**

- `WalletTest.testGetTransactionApprovedListSignatureBound` — verifies that a valid signature within `keysCount` succeeds, and that exceeding `keysCount` is rejected before any recovery (no unbounded loop).
- `WalletTest.testGetTransactionApprovedListTruncatesOversizedSignature` — verifies a 70-byte signature is truncated to 65 bytes in the returned transaction while still recovering the signer.

**Regression**

- Full `WalletTest`, `HttpServletTest`, `RpcApiServicesTest` (incl. existing `testGetTransactionApprovedList`), plus `framework` `checkstyleMain` / `checkstyleTest` — all green.

## Follow up

None.

## Extra details

`getTransactionApprovedList` now applies the same permission semantics as `getTransactionSignWeight` (it delegates to `checkWeight`). This changes the behavior of the endpoint in three ways — previously it would blindly recover every signature and return the resulting address list; now it rejects the request (returned as `OTHER_ERROR` / `SIGNATURE_FORMAT_ERROR`) when:

- **Too many signatures:** the signature count exceeds `permission.getKeysCount()`.
- **Signature not in the permission:** a recovered address is not one of the permission keys (weight 0).
- **Duplicate signer (new):** the same address signs more than once. The old loop performed no duplicate-address check and would happily return repeated entries; `checkWeight` now rejects with "has signed twice".

Callers that relied on the old "recover any signature" behavior to probe arbitrary signer addresses will see stricter results.

No database, consensus, or config changes; no hard-fork impact. Read-only API paths only.
